### PR TITLE
feat: Add Events section linking to Luma calendar

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -28,6 +28,16 @@ export function Footer() {
                     Blog
                   </Link>
                 </li>
+                <li>
+                  <a
+                    href="https://luma.com/user/02ship"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-gray-600 hover:text-gray-900"
+                  >
+                    Events
+                  </a>
+                </li>
               </ul>
             </div>
             <div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,6 +17,14 @@ export function Header() {
               <Link href="/blog" className="text-sm font-medium text-gray-700 hover:text-gray-900">
                 Blog
               </Link>
+              <a
+                href="https://luma.com/user/02ship"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm font-medium text-gray-700 hover:text-gray-900"
+              >
+                Events
+              </a>
               <Link href="/about" className="text-sm font-medium text-gray-700 hover:text-gray-900">
                 About
               </Link>


### PR DESCRIPTION
## Overview

Adds a new "Events" navigation link to the 02ship website that directs users to the Luma calendar.

## Changes

### Header Navigation
- ✅ Added "Events" link between "Blog" and "About"
- Opens in new tab with proper security attributes
- Consistent styling with other nav items

### Footer Navigation
- ✅ Added "Events" link in the "Learn" section
- Grouped with Courses and Blog for educational content
- Same external link behavior as header

## Link Details

**URL:** https://luma.com/user/02ship

**Attributes:**
- `target="_blank"` - Opens in new tab
- `rel="noopener noreferrer"` - Security best practices
- Consistent styling with existing navigation items

## User Benefits

📅 Easy access to 02ship events and workshops  
🎓 Discover upcoming learning opportunities  
👥 Connect with the community through events  
🔗 Centralized event calendar on Luma

## Visual Changes

**Desktop Header:**
```
Courses | Blog | Events | About
```

**Mobile/Footer:**
- Events link appears in the "Learn" section
- Consistent with other footer links

## Testing Checklist

- [x] Link points to correct URL
- [x] Opens in new tab
- [x] Styling matches existing nav items
- [x] Added to both header and footer
- [x] Responsive design maintained

---

**Ready to merge!** Simple, focused change with clear user value.