### PR TITLE
Add 'Lesson N - ' prefix to all Claude Basics course lesson names

### DIFF
--- a/content/courses/claude-basics/lesson-01-getting-started.json
+++ b/content/courses/claude-basics/lesson-01-getting-started.json
@@ -1,6 +1,6 @@
 {
   "slug": "getting-started",
-  "title": "Getting Started with Claude for Building Apps",
+  "title": "Lesson 1 - Getting Started with Claude for Building Apps",
   "description": "Learn what Claude is, set up your environment, and write your first app-building prompt that produces a runnable starter project.",
   "duration": "2-3 hours",
   "order": 1,

--- a/content/courses/claude-basics/lesson-02-prompting-fundamentals.json
+++ b/content/courses/claude-basics/lesson-02-prompting-fundamentals.json
@@ -1,6 +1,6 @@
 {
   "slug": "prompting-fundamentals",
-  "title": "Prompting Fundamentals",
+  "title": "Lesson 2 - Prompting Fundamentals",
   "description": "Master the core principles of effective prompting: clarity, context, constraints, and examples. Learn to craft prompts that get high-quality results consistently.",
   "duration": "2-3 hours",
   "order": 2,

--- a/content/courses/claude-basics/lesson-03-iteration-refinement.json
+++ b/content/courses/claude-basics/lesson-03-iteration-refinement.json
@@ -1,6 +1,6 @@
 {
   "slug": "iteration-refinement",
-  "title": "Iteration and Refinement Techniques",
+  "title": "Lesson 3 - Iteration and Refinement Techniques",
   "description": "Learn how to improve Claude's outputs through iteration, follow-up prompts, and refinement strategies. Turn good responses into great ones.",
   "duration": "2-3 hours",
   "order": 3,

--- a/content/courses/claude-basics/lesson-04-artifacts-code.json
+++ b/content/courses/claude-basics/lesson-04-artifacts-code.json
@@ -1,6 +1,6 @@
 {
   "slug": "artifacts-code",
-  "title": "Working with Code and Artifacts",
+  "title": "Lesson 4 - Working with Code and Artifacts",
   "description": "Learn to work with Claude's code artifacts: understanding what's generated, running code locally, making modifications, and building runnable projects without deep programming knowledge.",
   "duration": "2-3 hours",
   "order": 4,

--- a/content/courses/claude-basics/lesson-05-projects-context.json
+++ b/content/courses/claude-basics/lesson-05-projects-context.json
@@ -1,6 +1,6 @@
 {
   "slug": "projects-context",
-  "title": "Projects: Persistent Context Management",
+  "title": "Lesson 5 - Projects: Persistent Context Management",
   "description": "Master Claude's Projects feature to maintain context across sessions, organize complex builds, and work more efficiently with custom instructions and knowledge bases.",
   "duration": "2-3 hours",
   "order": 5,

--- a/content/courses/claude-basics/lesson-06-analysis-research.json
+++ b/content/courses/claude-basics/lesson-06-analysis-research.json
@@ -1,6 +1,6 @@
 {
   "slug": "analysis-research",
-  "title": "Analysis and Research with Claude",
+  "title": "Lesson 6 - Analysis and Research with Claude",
   "description": "Use Claude for data analysis, research synthesis, competitive analysis, and brainstorming — skills that apply to product building and beyond.",
   "duration": "2-3 hours",
   "order": 6,

--- a/content/courses/claude-basics/lesson-07-building-mvp.json
+++ b/content/courses/claude-basics/lesson-07-building-mvp.json
@@ -1,6 +1,6 @@
 {
   "slug": "building-mvp",
-  "title": "Building and Deploying Your MVP",
+  "title": "Lesson 7 - Building and Deploying Your MVP",
   "description": "Capstone lesson: Plan, build, and deploy a complete minimum viable product from scratch using everything you've learned. Ship your first product.",
   "duration": "2-3 hours",
   "order": 7,


### PR DESCRIPTION
Adds lesson number prefixes to all 7 lessons in the Claude Basics course for better clarity and navigation.

**Changes:**
- Lesson 1 - Getting Started with Claude for Building Apps
- Lesson 2 - Prompting Fundamentals
- Lesson 3 - Iteration and Refinement Techniques
- Lesson 4 - Working with Code and Artifacts
- Lesson 5 - Projects: Persistent Context Management
- Lesson 6 - Analysis and Research with Claude
- Lesson 7 - Building and Deploying Your MVP

All lesson JSON files updated with the new naming convention.