### PR TITLE
feat(seo): add comprehensive SEO/GEO infrastructure

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,9 +1,11 @@
+import type { Metadata } from 'next';
 import { Container } from '@/components/ui/Container';
 import { Button } from '@/components/ui/Button';
 
-export const metadata = {
-  title: 'About - 02Ship',
-  description: 'Learn more about 02Ship and our mission to make AI coding accessible to everyone.',
+export const metadata: Metadata = {
+  title: 'About 02Ship',
+  description: 'Learn about 02Ship — a learning platform helping non-programmers build and ship real projects with AI coding tools like Claude Code.',
+  alternates: { canonical: '/about' },
 };
 
 export default function AboutPage() {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -23,22 +23,19 @@ export async function generateMetadata({ params }: BlogPostPageProps) {
 
   if (!post) {
     return {
-      title: 'Post Not Found - 02Ship',
+      title: 'Post Not Found',
     };
   }
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
-  const url = `${siteUrl}/blog/${slug}`;
-
   return {
-    title: `${post.title} - 02Ship`,
+    title: post.title,
     description: post.excerpt,
     keywords: post.keywords || 'AI coding, Claude AI, build with AI, learning platform',
     authors: [{ name: post.author }],
     openGraph: {
       title: post.title,
       description: post.excerpt,
-      url: url,
+      url: `/blog/${slug}`,
       siteName: '02Ship',
       locale: 'en_US',
       type: 'article',
@@ -52,7 +49,7 @@ export async function generateMetadata({ params }: BlogPostPageProps) {
       creator: '@02ship',
     },
     alternates: {
-      canonical: url,
+      canonical: `/blog/${slug}`,
     },
   };
 }
@@ -65,7 +62,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     notFound();
   }
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.02ship.com';
   const url = `${siteUrl}/blog/${slug}`;
 
   const jsonLd = {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,10 +1,13 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Container } from '@/components/ui/Container';
 import { getAllBlogPosts } from '@/lib/content';
 
-export const metadata = {
-  title: 'Blog - 02Ship',
-  description: 'Tips, tutorials, and insights on building with AI tools.',
+export const metadata: Metadata = {
+  title: 'Blog — AI Coding Tips & Tutorials',
+  description:
+    'Tips, tutorials, and real build stories about creating projects with Claude Code and AI tools.',
+  alternates: { canonical: '/blog' },
 };
 
 export default async function BlogPage() {

--- a/src/app/courses/[series]/[lesson]/page.tsx
+++ b/src/app/courses/[series]/[lesson]/page.tsx
@@ -39,8 +39,15 @@ export async function generateMetadata({ params }: LessonPageProps) {
   }
 
   return {
-    title: `${lesson.title} - 02Ship`,
+    title: lesson.title,
     description: lesson.description,
+    openGraph: {
+      title: lesson.title,
+      description: lesson.description,
+      url: `/courses/${seriesSlug}/${lesson.slug}`,
+      type: 'article',
+    },
+    alternates: { canonical: `/courses/${seriesSlug}/${lesson.slug}` },
   };
 }
 
@@ -53,222 +60,258 @@ export default async function LessonPage({ params }: LessonPageProps) {
     notFound();
   }
 
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.02ship.com';
+  const lessonJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'LearningResource',
+    name: lesson.title,
+    description: lesson.description,
+    provider: { '@type': 'Organization', name: '02Ship', url: siteUrl },
+    url: `${siteUrl}/courses/${seriesSlug}/${lesson.slug}`,
+    timeRequired: lesson.duration,
+    isPartOf: {
+      '@type': 'Course',
+      name: series.title,
+      url: `${siteUrl}/courses/${seriesSlug}`,
+    },
+  };
+
   const currentIndex = series.lessons.findIndex((l) => l.slug === lessonSlug);
   const previousLesson = currentIndex > 0 ? series.lessons[currentIndex - 1] : null;
-  const nextLesson = currentIndex < series.lessons.length - 1 ? series.lessons[currentIndex + 1] : null;
+  const nextLesson =
+    currentIndex < series.lessons.length - 1 ? series.lessons[currentIndex + 1] : null;
 
   return (
-    <div className="py-20">
-      <Container>
-        <div className="mx-auto max-w-4xl">
-          <div className="mb-6">
-            <Link
-              href={`/courses/${seriesSlug}`}
-              className="text-sm font-medium text-blue-600 hover:text-blue-700"
-            >
-              ← Back to {series.title}
-            </Link>
-          </div>
-
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900">
-            {lesson.title}
-          </h1>
-          <p className="mt-4 text-lg text-gray-600">{lesson.description}</p>
-          <p className="mt-2 text-sm text-gray-600">Duration: {lesson.duration}</p>
-
-          {/* Learning Objectives */}
-          {lesson.learningObjectives && lesson.learningObjectives.length > 0 && (
-            <div className="mt-8 rounded-lg bg-blue-50 p-6">
-              <h2 className="text-xl font-semibold text-gray-900">Learning Objectives</h2>
-              <p className="mt-2 text-sm text-gray-600">By the end of this lesson, you will be able to:</p>
-              <ul className="mt-4 space-y-2">
-                {lesson.learningObjectives.map((objective, index) => (
-                  <li key={index} className="flex items-start">
-                    <span className="mr-2 text-blue-600">✓</span>
-                    <span className="text-gray-700">{objective}</span>
-                  </li>
-                ))}
-              </ul>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(lessonJsonLd) }}
+      />
+      <div className="py-20">
+        <Container>
+          <div className="mx-auto max-w-4xl">
+            <div className="mb-6">
+              <Link
+                href={`/courses/${seriesSlug}`}
+                className="text-sm font-medium text-blue-600 hover:text-blue-700"
+              >
+                &larr; Back to {series.title}
+              </Link>
             </div>
-          )}
 
-          {/* Videos Section */}
-          {lesson.videos && lesson.videos.length > 0 ? (
-            <div className="mt-12">
-              <h2 className="text-2xl font-bold text-gray-900">Videos</h2>
-              <div className="mt-6 space-y-8">
-                {lesson.videos.map((video, index) => (
-                  <div key={index} className="rounded-lg border border-gray-200 p-6">
-                    <h3 className="text-xl font-semibold text-gray-900">{video.title}</h3>
-                    <p className="mt-2 text-gray-600">{video.description}</p>
-                    {video.estimatedDuration && (
-                      <p className="mt-1 text-sm text-gray-500">Duration: {video.estimatedDuration}</p>
-                    )}
-                    <div className="mt-4">
-                      {video.youtubeId && video.youtubeId !== '[To be recorded]' ? (
-                        <VideoPlayer youtubeId={video.youtubeId} title={video.title} />
-                      ) : (
-                        <div className="flex h-64 items-center justify-center rounded-lg bg-gray-100">
-                          <p className="text-gray-500">Video coming soon</p>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ) : lesson.youtubeId ? (
-            // Legacy single video support
-            <div className="mt-8">
-              <VideoPlayer youtubeId={lesson.youtubeId} title={lesson.title} />
-            </div>
-          ) : null}
+            <h1 className="text-4xl font-bold tracking-tight text-gray-900">{lesson.title}</h1>
+            <p className="mt-4 text-lg text-gray-600">{lesson.description}</p>
+            <p className="mt-2 text-sm text-gray-600">Duration: {lesson.duration}</p>
 
-          {/* Text Sections */}
-          {lesson.textSections && lesson.textSections.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-2xl font-bold text-gray-900">Key Concepts</h2>
-              <div className="mt-6 space-y-6">
-                {lesson.textSections.map((section, index) => (
-                  <div key={index} className="rounded-lg bg-gray-50 p-6">
-                    <h3 className="text-lg font-semibold text-gray-900">{section.title}</h3>
-                    <div className="mt-3 whitespace-pre-wrap text-gray-700">{section.content}</div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Common Mistakes */}
-          {lesson.commonMistakes && lesson.commonMistakes.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-2xl font-bold text-gray-900">Common Mistakes & Pitfalls</h2>
-              <div className="mt-6 space-y-4">
-                {lesson.commonMistakes.map((item, index) => (
-                  <div key={index} className="rounded-lg border-l-4 border-yellow-500 bg-yellow-50 p-4">
-                    <h3 className="font-semibold text-gray-900">❌ {item.mistake}</h3>
-                    <p className="mt-1 text-gray-700">{item.explanation}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Exercises */}
-          {lesson.exercises && lesson.exercises.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-2xl font-bold text-gray-900">Exercises</h2>
-              <div className="mt-6 space-y-6">
-                {lesson.exercises.map((exercise, index) => (
-                  <div key={index} className="rounded-lg border border-gray-200 p-6">
-                    <div className="flex items-start justify-between">
-                      <h3 className="text-lg font-semibold text-gray-900">Exercise {index + 1}: {exercise.title}</h3>
-                      <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700">
-                        {exercise.estimatedTime}
-                      </span>
-                    </div>
-                    <p className="mt-3 text-gray-700">{exercise.description}</p>
-                    <div className="mt-4">
-                      <p className="text-sm font-medium text-gray-900">Expected Output:</p>
-                      <p className="mt-1 text-gray-600">{exercise.output}</p>
-                    </div>
-                    {Array.isArray(exercise.successCriteria) ? (
-                      <div className="mt-4">
-                        <p className="text-sm font-medium text-gray-900">Success Criteria:</p>
-                        <ul className="mt-2 space-y-1">
-                          {exercise.successCriteria.map((criteria, idx) => (
-                            <li key={idx} className="flex items-start text-sm text-gray-600">
-                              <span className="mr-2">•</span>
-                              <span>{criteria}</span>
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-                    ) : (
-                      <div className="mt-4">
-                        <p className="text-sm italic text-gray-600">{exercise.successCriteria}</p>
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Reflection Questions */}
-          {lesson.reflectionQuestions && lesson.reflectionQuestions.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-2xl font-bold text-gray-900">Lesson Reflection</h2>
-              <div className="mt-6 rounded-lg bg-purple-50 p-6">
-                <p className="text-sm text-gray-600">Take a moment to reflect on what you&apos;ve learned:</p>
-                <ul className="mt-4 space-y-3">
-                  {lesson.reflectionQuestions.map((question, index) => (
-                    <li key={index} className="text-gray-700">
-                      <span className="font-medium">{index + 1}.</span> {question}
+            {/* Learning Objectives */}
+            {lesson.learningObjectives && lesson.learningObjectives.length > 0 && (
+              <div className="mt-8 rounded-lg bg-blue-50 p-6">
+                <h2 className="text-xl font-semibold text-gray-900">Learning Objectives</h2>
+                <p className="mt-2 text-sm text-gray-600">
+                  By the end of this lesson, you will be able to:
+                </p>
+                <ul className="mt-4 space-y-2">
+                  {lesson.learningObjectives.map((objective, index) => (
+                    <li key={index} className="flex items-start">
+                      <span className="mr-2 text-blue-600">&#10003;</span>
+                      <span className="text-gray-700">{objective}</span>
                     </li>
                   ))}
                 </ul>
               </div>
-            </div>
-          )}
+            )}
 
-          {/* Resources */}
-          {lesson.resources && lesson.resources.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-2xl font-bold text-gray-900">Resources & Further Reading</h2>
-              <div className="mt-6 space-y-3">
-                {lesson.resources.map((resource, index) => (
-                  <a
-                    key={index}
-                    href={resource.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center text-blue-600 hover:text-blue-700"
-                  >
-                    <span className="mr-2">📖</span>
-                    <span>{resource.title}</span>
-                    <span className="ml-2">→</span>
-                  </a>
-                ))}
+            {/* Videos Section */}
+            {lesson.videos && lesson.videos.length > 0 ? (
+              <div className="mt-12">
+                <h2 className="text-2xl font-bold text-gray-900">Videos</h2>
+                <div className="mt-6 space-y-8">
+                  {lesson.videos.map((video, index) => (
+                    <div key={index} className="rounded-lg border border-gray-200 p-6">
+                      <h3 className="text-xl font-semibold text-gray-900">{video.title}</h3>
+                      <p className="mt-2 text-gray-600">{video.description}</p>
+                      {video.estimatedDuration && (
+                        <p className="mt-1 text-sm text-gray-500">
+                          Duration: {video.estimatedDuration}
+                        </p>
+                      )}
+                      <div className="mt-4">
+                        {video.youtubeId && video.youtubeId !== '[To be recorded]' ? (
+                          <VideoPlayer youtubeId={video.youtubeId} title={video.title} />
+                        ) : (
+                          <div className="flex h-64 items-center justify-center rounded-lg bg-gray-100">
+                            <p className="text-gray-500">Video coming soon</p>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
-            </div>
-          )}
-
-          {/* Legacy Transcript */}
-          {lesson.transcript && (
-            <div className="mt-12">
-              <h2 className="text-2xl font-bold text-gray-900">Transcript</h2>
-              <div className="mt-4 whitespace-pre-wrap text-gray-600">
-                {lesson.transcript}
+            ) : lesson.youtubeId ? (
+              // Legacy single video support
+              <div className="mt-8">
+                <VideoPlayer youtubeId={lesson.youtubeId} title={lesson.title} />
               </div>
-            </div>
-          )}
+            ) : null}
 
-          {/* Navigation */}
-          <div className="mt-12 flex items-center justify-between border-t border-gray-200 pt-8">
-            <div>
-              {previousLesson ? (
-                <Link href={`/courses/${seriesSlug}/${previousLesson.slug}`}>
-                  <Button variant="outline">← Previous Lesson</Button>
-                </Link>
-              ) : (
-                <div />
-              )}
-            </div>
-            <div>
-              {nextLesson ? (
-                <Link href={`/courses/${seriesSlug}/${nextLesson.slug}`}>
-                  <Button>Next Lesson →</Button>
-                </Link>
-              ) : (
-                <Link href={`/courses/${seriesSlug}`}>
-                  <Button variant="outline">Back to Course</Button>
-                </Link>
-              )}
+            {/* Text Sections */}
+            {lesson.textSections && lesson.textSections.length > 0 && (
+              <div className="mt-12">
+                <h2 className="text-2xl font-bold text-gray-900">Key Concepts</h2>
+                <div className="mt-6 space-y-6">
+                  {lesson.textSections.map((section, index) => (
+                    <div key={index} className="rounded-lg bg-gray-50 p-6">
+                      <h3 className="text-lg font-semibold text-gray-900">{section.title}</h3>
+                      <div className="mt-3 whitespace-pre-wrap text-gray-700">
+                        {section.content}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Common Mistakes */}
+            {lesson.commonMistakes && lesson.commonMistakes.length > 0 && (
+              <div className="mt-12">
+                <h2 className="text-2xl font-bold text-gray-900">Common Mistakes & Pitfalls</h2>
+                <div className="mt-6 space-y-4">
+                  {lesson.commonMistakes.map((item, index) => (
+                    <div
+                      key={index}
+                      className="rounded-lg border-l-4 border-yellow-500 bg-yellow-50 p-4"
+                    >
+                      <h3 className="font-semibold text-gray-900">
+                        &#10060; {item.mistake}
+                      </h3>
+                      <p className="mt-1 text-gray-700">{item.explanation}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Exercises */}
+            {lesson.exercises && lesson.exercises.length > 0 && (
+              <div className="mt-12">
+                <h2 className="text-2xl font-bold text-gray-900">Exercises</h2>
+                <div className="mt-6 space-y-6">
+                  {lesson.exercises.map((exercise, index) => (
+                    <div key={index} className="rounded-lg border border-gray-200 p-6">
+                      <div className="flex items-start justify-between">
+                        <h3 className="text-lg font-semibold text-gray-900">
+                          Exercise {index + 1}: {exercise.title}
+                        </h3>
+                        <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700">
+                          {exercise.estimatedTime}
+                        </span>
+                      </div>
+                      <p className="mt-3 text-gray-700">{exercise.description}</p>
+                      <div className="mt-4">
+                        <p className="text-sm font-medium text-gray-900">Expected Output:</p>
+                        <p className="mt-1 text-gray-600">{exercise.output}</p>
+                      </div>
+                      {Array.isArray(exercise.successCriteria) ? (
+                        <div className="mt-4">
+                          <p className="text-sm font-medium text-gray-900">Success Criteria:</p>
+                          <ul className="mt-2 space-y-1">
+                            {exercise.successCriteria.map((criteria, idx) => (
+                              <li key={idx} className="flex items-start text-sm text-gray-600">
+                                <span className="mr-2">&bull;</span>
+                                <span>{criteria}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      ) : (
+                        <div className="mt-4">
+                          <p className="text-sm italic text-gray-600">
+                            {exercise.successCriteria}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Reflection Questions */}
+            {lesson.reflectionQuestions && lesson.reflectionQuestions.length > 0 && (
+              <div className="mt-12">
+                <h2 className="text-2xl font-bold text-gray-900">Lesson Reflection</h2>
+                <div className="mt-6 rounded-lg bg-purple-50 p-6">
+                  <p className="text-sm text-gray-600">
+                    Take a moment to reflect on what you&apos;ve learned:
+                  </p>
+                  <ul className="mt-4 space-y-3">
+                    {lesson.reflectionQuestions.map((question, index) => (
+                      <li key={index} className="text-gray-700">
+                        <span className="font-medium">{index + 1}.</span> {question}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            )}
+
+            {/* Resources */}
+            {lesson.resources && lesson.resources.length > 0 && (
+              <div className="mt-12">
+                <h2 className="text-2xl font-bold text-gray-900">Resources & Further Reading</h2>
+                <div className="mt-6 space-y-3">
+                  {lesson.resources.map((resource, index) => (
+                    <a
+                      key={index}
+                      href={resource.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center text-blue-600 hover:text-blue-700"
+                    >
+                      <span className="mr-2">&#128214;</span>
+                      <span>{resource.title}</span>
+                      <span className="ml-2">&rarr;</span>
+                    </a>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Legacy Transcript */}
+            {lesson.transcript && (
+              <div className="mt-12">
+                <h2 className="text-2xl font-bold text-gray-900">Transcript</h2>
+                <div className="mt-4 whitespace-pre-wrap text-gray-600">{lesson.transcript}</div>
+              </div>
+            )}
+
+            {/* Navigation */}
+            <div className="mt-12 flex items-center justify-between border-t border-gray-200 pt-8">
+              <div>
+                {previousLesson ? (
+                  <Link href={`/courses/${seriesSlug}/${previousLesson.slug}`}>
+                    <Button variant="outline">&larr; Previous Lesson</Button>
+                  </Link>
+                ) : (
+                  <div />
+                )}
+              </div>
+              <div>
+                {nextLesson ? (
+                  <Link href={`/courses/${seriesSlug}/${nextLesson.slug}`}>
+                    <Button>Next Lesson &rarr;</Button>
+                  </Link>
+                ) : (
+                  <Link href={`/courses/${seriesSlug}`}>
+                    <Button variant="outline">Back to Course</Button>
+                  </Link>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      </Container>
-    </div>
+        </Container>
+      </div>
+    </>
   );
 }

--- a/src/app/courses/[series]/page.tsx
+++ b/src/app/courses/[series]/page.tsx
@@ -27,8 +27,14 @@ export async function generateMetadata({ params }: SeriesPageProps) {
   }
 
   return {
-    title: `${series.title} - 02Ship`,
+    title: series.title,
     description: series.description,
+    openGraph: {
+      title: series.title,
+      description: series.description,
+      url: `/courses/${series.slug}`,
+    },
+    alternates: { canonical: `/courses/${series.slug}` },
   };
 }
 
@@ -40,31 +46,53 @@ export default async function SeriesPage({ params }: SeriesPageProps) {
     notFound();
   }
 
-  return (
-    <div className="py-20">
-      <Container>
-        <div className="mx-auto max-w-2xl">
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-            {series.title}
-          </h1>
-          <p className="mt-4 text-lg text-gray-600">{series.description}</p>
-          <p className="mt-2 text-sm text-gray-600">
-            {series.lessons.length} {series.lessons.length === 1 ? 'lesson' : 'lessons'}
-          </p>
-        </div>
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.02ship.com';
+  const courseJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Course',
+    name: series.title,
+    description: series.description,
+    provider: { '@type': 'Organization', name: '02Ship', url: siteUrl },
+    url: `${siteUrl}/courses/${series.slug}`,
+    numberOfLessons: series.lessons.length,
+    hasCourseInstance: {
+      '@type': 'CourseInstance',
+      courseMode: 'online',
+      courseWorkload: `${series.lessons.length} lessons`,
+    },
+  };
 
-        <div className="mt-16 space-y-4">
-          {series.lessons.length > 0 ? (
-            series.lessons.map((lesson) => (
-              <LessonCard key={lesson.slug} lesson={lesson} seriesSlug={series.slug} />
-            ))
-          ) : (
-            <div className="text-center text-gray-600">
-              <p>No lessons available yet. Check back soon!</p>
-            </div>
-          )}
-        </div>
-      </Container>
-    </div>
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(courseJsonLd) }}
+      />
+      <div className="py-20">
+        <Container>
+          <div className="mx-auto max-w-2xl">
+            <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+              {series.title}
+            </h1>
+            <p className="mt-4 text-lg text-gray-600">{series.description}</p>
+            <p className="mt-2 text-sm text-gray-600">
+              {series.lessons.length} {series.lessons.length === 1 ? 'lesson' : 'lessons'}
+            </p>
+          </div>
+
+          <div className="mt-16 space-y-4">
+            {series.lessons.length > 0 ? (
+              series.lessons.map((lesson) => (
+                <LessonCard key={lesson.slug} lesson={lesson} seriesSlug={series.slug} />
+              ))
+            ) : (
+              <div className="text-center text-gray-600">
+                <p>No lessons available yet. Check back soon!</p>
+              </div>
+            )}
+          </div>
+        </Container>
+      </div>
+    </>
   );
 }

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,10 +1,13 @@
+import type { Metadata } from 'next';
 import { Container } from '@/components/ui/Container';
 import { SeriesCard } from '@/components/courses/SeriesCard';
 import { getAllSeries } from '@/lib/content';
 
-export const metadata = {
-  title: 'Courses - 02Ship',
-  description: 'Browse our courses and start learning to build with AI tools.',
+export const metadata: Metadata = {
+  title: 'AI Coding Courses for Beginners',
+  description:
+    'Free step-by-step video courses to build and ship real projects with Claude Code and AI tools. No coding experience needed.',
+  alternates: { canonical: '/courses' },
 };
 
 export default async function CoursesPage() {

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from 'next';
 import { Container } from '@/components/ui/Container';
 
 export const metadata: Metadata = {
-  title: 'Events - 02Ship',
+  title: 'Events — AI Builder Meetups & Workshops',
   description:
-    'Join our upcoming meetups and workshops for AI builders. Learn to build and ship with Claude Code and other AI tools.',
+    'Join upcoming meetups and workshops for AI builders. Learn to build and ship with Claude Code and other AI tools.',
+  alternates: { canonical: '/events' },
 };
 
 export default function EventsPage() {

--- a/src/app/news/[date]/page.tsx
+++ b/src/app/news/[date]/page.tsx
@@ -25,8 +25,16 @@ export async function generateMetadata({ params }: DailyNewsPageProps) {
   });
 
   return {
-    title: `AI News — ${formatted} - 02Ship`,
+    title: `AI News — ${formatted}`,
     description: `Top AI news for ${formatted}, curated from Hacker News, Reddit, arXiv, and Hugging Face.`,
+    openGraph: {
+      title: `AI News — ${formatted}`,
+      description: `Top AI news for ${formatted}`,
+      type: 'article' as const,
+    },
+    alternates: {
+      canonical: `/news/${date}`,
+    },
   };
 }
 

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,10 +1,12 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Container } from '@/components/ui/Container';
 import { getAllNewsDates } from '@/lib/news';
 
-export const metadata = {
-  title: 'AI News - 02Ship',
-  description: 'Daily curated AI news from Hacker News, Reddit, arXiv, and Hugging Face.',
+export const metadata: Metadata = {
+  title: 'Daily AI News — Curated & Ranked',
+  description: 'Daily curated AI news from Hacker News, Reddit, arXiv, and Hugging Face, ranked by impact.',
+  alternates: { canonical: '/news' },
 };
 
 export default async function NewsPage() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,18 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Container } from '@/components/ui/Container';
 import { Button } from '@/components/ui/Button';
+
+export const metadata: Metadata = {
+  title: {
+    absolute: '02Ship — Learn to Build & Ship with AI (Zero Coding Required)',
+  },
+  description:
+    'Step-by-step courses for non-programmers to build and ship real projects using Claude Code and AI tools. Go from idea to live product with zero coding experience.',
+  alternates: {
+    canonical: '/',
+  },
+};
 
 export default function HomePage() {
   return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.02ship.com';
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,80 @@
+import { MetadataRoute } from 'next';
+import { getAllSeries, getAllBlogPosts } from '@/lib/content';
+import { getAllNewsDates } from '@/lib/news';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.02ship.com';
+
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}/courses`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: `${siteUrl}/blog`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: `${siteUrl}/news`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.8,
+    },
+    {
+      url: `${siteUrl}/events`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.6,
+    },
+    {
+      url: `${siteUrl}/about`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  ];
+
+  const allSeries = await getAllSeries();
+  const coursePages: MetadataRoute.Sitemap = allSeries.flatMap((series) => [
+    {
+      url: `${siteUrl}/courses/${series.slug}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.8,
+    },
+    ...series.lessons.map((lesson) => ({
+      url: `${siteUrl}/courses/${series.slug}/${lesson.slug}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    })),
+  ]);
+
+  const blogPosts = await getAllBlogPosts();
+  const blogPages: MetadataRoute.Sitemap = blogPosts.map((post) => ({
+    url: `${siteUrl}/blog/${post.slug}`,
+    lastModified: new Date(post.date),
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }));
+
+  const newsDates = await getAllNewsDates();
+  const newsPages: MetadataRoute.Sitemap = newsDates.map((date) => ({
+    url: `${siteUrl}/news/${date}`,
+    lastModified: new Date(date),
+    changeFrequency: 'never' as const,
+    priority: 0.5,
+  }));
+
+  return [...staticPages, ...coursePages, ...blogPages, ...newsPages];
+}


### PR DESCRIPTION
## Summary

- Add dynamic `sitemap.xml` covering all routes (static pages, courses, lessons, blog posts, news dates)
- Add `robots.txt` with sitemap reference
- Add homepage metadata with targeted keywords for AI coding beginners
- Add OpenGraph, canonical URLs, and JSON-LD structured data (`Course`, `LearningResource`) to course/lesson pages
- Improve blog metadata with relative canonical URLs (leveraging `metadataBase`)
- Add metadata and canonical URLs to news, events, and about pages
- Standardize title format using root layout template (`%s | 02Ship`)

**Note:** Root layout changes (metadataBase, title template, global OG/Twitter defaults, Organization + WebSite JSON-LD) were included in a prior commit on main.

## Before → After

| Feature | Before | After |
|---------|--------|-------|
| Sitemap | None (404) | Dynamic, all routes |
| Robots.txt | None (404) | Allow all + sitemap ref |
| OG tags | Blog posts only | All pages |
| Canonical URLs | Blog posts only | All pages |
| JSON-LD | BlogPosting only | + Course, LearningResource |
| Title format | Manual ` - 02Ship` | Template `%s \| 02Ship` |

## Test plan

- [x] `npm run lint` — no warnings/errors
- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — 30 pages, 0 errors
- [ ] Verify `/sitemap.xml` renders all routes after deploy
- [ ] Verify `/robots.txt` renders with sitemap reference
- [ ] Test social sharing preview (OG tags) with https://www.opengraph.xyz/

🤖 Generated with [Claude Code](https://claude.com/claude-code)