### PR TITLE
feat: add contribution CTA to about and events pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -111,6 +111,35 @@ export default function AboutPage() {
             </div>
           </div>
 
+          {/* Bring Your Talent CTA */}
+          <div className="mt-16">
+            <a
+              href="https://forms.gle/wT2d2zZ47waQAviC8"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block rounded-xl border border-amber-200 bg-amber-50 p-6 transition-all hover:border-amber-300 hover:shadow-md"
+            >
+              <div className="flex items-start gap-4">
+                <span className="text-3xl" aria-hidden="true">
+                  🍲
+                </span>
+                <div>
+                  <h3 className="text-lg font-bold text-amber-900">
+                    Bring Your Talent to the Pot
+                  </h3>
+                  <p className="mt-1 text-amber-800">
+                    We&apos;re looking for volunteers, speakers, mentors, and
+                    content creators. Everyone has an ingredient to
+                    contribute — what&apos;s yours?
+                  </p>
+                  <span className="mt-3 inline-block rounded-md bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-700">
+                    Share Your Talent
+                  </span>
+                </div>
+              </div>
+            </a>
+          </div>
+
           {/* Community Section */}
           <div className="mt-16">
             <h2 className="text-2xl font-bold text-gray-900">

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -44,6 +44,30 @@ export default function EventsPage() {
             </span>
           </a>
 
+          <a
+            href="https://forms.gle/wT2d2zZ47waQAviC8"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-4 py-3"
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-lg" aria-hidden="true">
+                🍲
+              </span>
+              <div>
+                <p className="text-sm font-semibold text-amber-800">
+                  Bring your talent to the pot
+                </p>
+                <p className="text-xs text-amber-600">
+                  Volunteer, speak, mentor, or create content with us
+                </p>
+              </div>
+            </div>
+            <span className="rounded-md bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-700">
+              Contribute
+            </span>
+          </a>
+
           <div className="mt-6">
             <iframe
               src="https://luma.com/embed/calendar/cal-zhuelVReFdNX5xm/events"


### PR DESCRIPTION
## Summary

- Added "Bring Your Talent to the Pot" CTA linking to Google Form on both `/about` and `/events` pages
- Form collects volunteers, speakers, mentors, and content creators
- Amber theme to match the Stone Soup motif already on the about page
- `/about`: larger card-style CTA placed between the Stone Soup story and community section
- `/events`: compact banner matching the existing Lu.ma subscribe banner style

## Test plan

- [x] `npm run lint` — passes
- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes
- [ ] Verify form link opens correctly on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)