### PR TITLE
fix(news): upgrade to Gemini 3.1 Pro and harden daily news pipeline

### DIFF
--- a/scripts/generate-news.mjs
+++ b/scripts/generate-news.mjs
@@ -238,7 +238,7 @@ function preFilterItems(items, maxItems = 60) {
 // --- Gemini ---
 
 async function rankWithGemini(items, retries = 2) {
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=${GEMINI_API_KEY}`;
 
   // Send compact JSON to reduce input token usage
   const itemsJson = JSON.stringify(items.map(({ title, url, source, rawScore }) => ({ title, url, source, rawScore })));
@@ -274,8 +274,9 @@ ${itemsJson}`;
         contents: [{ parts: [{ text: prompt }] }],
         generationConfig: {
           temperature: 0.3,
-          maxOutputTokens: 16384,
+          maxOutputTokens: 65536,
           responseMimeType: 'application/json',
+          thinkingConfig: { thinkingBudget: 2048 },
         },
       }),
     });


### PR DESCRIPTION
## Summary
- Upgrade from `gemini-2.5-flash` to `gemini-3.1-pro-preview` (65K max output tokens, capped thinking budget)
- Pre-filter items to top 60 by source diversity + score before sending to Gemini
- Send compact JSON and use `responseMimeType: 'application/json'` for structured output
- Add retry logic (up to 2 retries with backoff) for Gemini API errors and parse failures
- Add `git pull --rebase` before push in CI to prevent rejection on concurrent commits
- Filter stale HN items and deduplicate across days

## Test plan
- [ ] Merge and re-run the Daily AI News workflow
- [ ] Verify the generated `content/news/<date>.json` has 15 ranked items
- [ ] Confirm no JSON truncation errors in the action logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)