### PR TITLE
fix(news): remove Reddit and upgrade to Gemini 3.1 Pro

### DIFF
--- a/scripts/generate-news.mjs
+++ b/scripts/generate-news.mjs
@@ -29,20 +29,6 @@ async function fetchHackerNews() {
   }));
 }
 
-async function fetchReddit() {
-  const url = 'https://www.reddit.com/r/MachineLearning+LocalLLaMA/top.json?t=day&limit=30';
-  const res = await fetch(url, {
-    headers: { 'User-Agent': '02ship-news-bot/1.0' },
-  });
-  const data = await res.json();
-  return (data?.data?.children || []).map(child => ({
-    title: child.data.title,
-    url: child.data.url,
-    source: 'Reddit',
-    rawScore: child.data.score,
-  }));
-}
-
 async function fetchArxiv() {
   const parser = new XMLParser();
   const categories = ['cs.AI', 'cs.CL', 'cs.LG'];
@@ -323,7 +309,6 @@ async function main() {
   console.log('Fetching sources...');
   const sources = [
     { name: 'HN', fn: fetchHackerNews },
-    { name: 'Reddit', fn: fetchReddit },
     { name: 'arXiv', fn: fetchArxiv },
     { name: 'HF', fn: fetchHuggingFace },
     { name: 'ProductHunt', fn: fetchProductHunt },


### PR DESCRIPTION
## Summary
- Remove Reddit as a news source (consistently returns HTML instead of JSON in CI)
- Upgrade to `gemini-3.1-pro-preview` with 65K max output tokens and capped thinking budget
- Pre-filter items to top 60 by source diversity + score before sending to Gemini
- Send compact JSON with `responseMimeType: 'application/json'` for structured output
- Add retry logic (up to 2 retries with backoff) for API errors and parse failures
- Add `git pull --rebase` before push in CI to prevent rejection on concurrent commits

## Test plan
- [ ] Merge and re-run the Daily AI News workflow
- [ ] Verify no Reddit fetch errors in logs
- [ ] Verify generated `content/news/<date>.json` has 15 ranked items with no truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)