### PR TITLE
fix(news): use gemini-2.5-flash with thinking budget cap

### DIFF
--- a/scripts/generate-news.mjs
+++ b/scripts/generate-news.mjs
@@ -224,7 +224,7 @@ function preFilterItems(items, maxItems = 60) {
 // --- Gemini ---
 
 async function rankWithGemini(items, retries = 2) {
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=${GEMINI_API_KEY}`;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_API_KEY}`;
 
   // Send compact JSON to reduce input token usage
   const itemsJson = JSON.stringify(items.map(({ title, url, source, rawScore }) => ({ title, url, source, rawScore })));
@@ -260,7 +260,7 @@ ${itemsJson}`;
         contents: [{ parts: [{ text: prompt }] }],
         generationConfig: {
           temperature: 0.3,
-          maxOutputTokens: 65536,
+          maxOutputTokens: 16384,
           responseMimeType: 'application/json',
           thinkingConfig: { thinkingBudget: 2048 },
         },


### PR DESCRIPTION
## Summary
- Switch to `gemini-2.5-flash` with `thinkingBudget: 2048` to cap reasoning overhead
- Set `maxOutputTokens: 16384` for the JSON response

## Test plan
- [ ] Re-run the Daily AI News workflow and verify it completes successfully
- [ ] Verify no JSON truncation errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)