### PR TITLE
fix: link Join Community button to /community page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,15 +32,11 @@ export default function HomePage() {
               <Link href="/courses">
                 <Button size="lg">Start Learning</Button>
               </Link>
-              <a
-                href="https://discord.gg/btqaA3hzKp"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <Link href="/community">
                 <Button variant="outline" size="lg">
                   Join Community
                 </Button>
-              </a>
+              </Link>
             </div>
           </div>
         </Container>


### PR DESCRIPTION
## Summary
- Homepage "Join Community" button now links to `/community` page instead of directly to the Discord invite URL
- Uses Next.js `Link` for client-side navigation instead of external `<a>` tag

## Test plan
- [ ] Verify "Join Community" button on homepage navigates to `/community`
- [ ] Verify it uses client-side navigation (no full page reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)