### PR TITLE
feat: add autoresearch skill for skill optimization

### DIFF
--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: autoresearch
+description: "Autonomously optimize any Claude Code skill by running it repeatedly, scoring outputs against binary evals, mutating the prompt, and keeping improvements. Based on Karpathy's autoresearch methodology. Use when: optimize this skill, improve this skill, run autoresearch on, make this skill better, self-improve skill, benchmark skill, eval my skill, run evals on. Outputs: an improved SKILL.md, a results log, and a changelog of every mutation tried."
+user-invocable: true
+---
+
+# Autoresearch for Skills
+
+Autonomous experimentation loop that optimizes skill prompts. Run a skill repeatedly, score outputs against binary evals, mutate the prompt, keep improvements, discard the rest.
+
+## Before Starting: Gather Context
+
+**STOP. Confirm all fields with the user before running any experiments.**
+
+1. **Target skill** — Exact path to SKILL.md
+2. **Test inputs** — 3-5 prompts/scenarios covering different use cases (avoid overfitting)
+3. **Eval criteria** — 3-6 binary yes/no checks. See [references/eval-guide.md](references/eval-guide.md)
+4. **Runs per experiment** — Default: 5
+5. **Budget cap** — Optional max experiment cycles. Default: no cap
+
+## Step 1: Read the Skill
+
+Read the full SKILL.md and any linked `references/` files. Understand the skill's core job, process, output format, and existing quality checks.
+
+## Step 2: Build the Eval Suite
+
+Format each eval from the user's criteria:
+
+```
+EVAL [N]: [Short name]
+Question: [Yes/no question]
+Pass: [What "yes" looks like]
+Fail: [What triggers "no"]
+```
+
+Max score = `[number of evals] x [runs per experiment]`.
+
+For guidance on writing effective evals, see [references/eval-guide.md](references/eval-guide.md).
+
+## Step 3: Set Up Working Directory
+
+Create `autoresearch-[skill-name]/` inside the skill's folder with:
+
+```
+autoresearch-[skill-name]/
+├── dashboard.html       # copy from assets/dashboard-template.html
+├── results.json         # data powering the dashboard
+├── results.tsv          # tab-separated score log
+├── changelog.md         # mutation log
+└── SKILL.md.baseline    # backup of original skill
+```
+
+**Dashboard:** Copy [assets/dashboard-template.html](assets/dashboard-template.html) to `dashboard.html`. Open it: `open dashboard.html`. It auto-refreshes from results.json every 10 seconds.
+
+**results.json schema:**
+
+```json
+{
+  "skill_name": "[name]",
+  "status": "running|complete",
+  "current_experiment": 0,
+  "baseline_score": 0.0,
+  "best_score": 0.0,
+  "experiments": [
+    { "id": 0, "score": 14, "max_score": 20, "pass_rate": 70.0, "status": "baseline|keep|discard", "description": "..." }
+  ],
+  "eval_breakdown": [
+    { "name": "Eval name", "pass_count": 8, "total": 10 }
+  ]
+}
+```
+
+**results.tsv format:**
+
+```
+experiment	score	max_score	pass_rate	status	description
+0	14	20	70.0%	baseline	original skill — no changes
+```
+
+## Step 4: Establish Baseline
+
+Run the skill AS-IS (experiment #0). Score every output against every eval. Record baseline in results.tsv and results.json.
+
+After baseline, confirm score with user. If already 90%+, ask if they want to continue.
+
+## Step 5: Run the Experiment Loop
+
+Run autonomously until stopped. Each cycle:
+
+1. **Analyze failures** — Which evals fail most? What pattern?
+2. **Hypothesize** — Pick ONE thing to change
+3. **Mutate** — Edit SKILL.md with one targeted change
+4. **Run** — Execute skill [N] times with same test inputs
+5. **Score** — Run outputs through all evals
+6. **Keep or discard:**
+   - Improved -> KEEP (new baseline)
+   - Same or worse -> DISCARD (revert SKILL.md)
+7. **Log** — Update results.tsv, results.json, and changelog.md
+8. **Repeat**
+
+**Mutation guidelines:**
+- One change per cycle (isolate what helps)
+- Good: specific instructions for common failures, reworded ambiguities, anti-patterns, moved priority, added examples, removed over-optimizing rules
+- Bad: full rewrites, 10 rules at once, vague additions
+
+**Stop conditions:**
+- User stops you
+- Budget cap hit
+- 95%+ pass rate for 3 consecutive experiments
+
+**If stuck:** Re-read failing outputs. Combine near-miss mutations. Try removing instead of adding.
+
+## Step 6: Changelog
+
+Append to `changelog.md` after each experiment:
+
+```markdown
+## Experiment [N] — [keep/discard]
+
+**Score:** [X]/[max] ([percent]%)
+**Change:** [One sentence]
+**Reasoning:** [Why expected to help]
+**Result:** [Which evals improved/declined]
+**Failing outputs:** [What still fails]
+```
+
+## Step 7: Deliver Results
+
+Present: score summary (baseline -> final), total experiments, keep rate, top 3 changes, remaining failure patterns, location of artifacts.
+
+## Example
+
+Diagram-generator skill, 4 evals, 10 runs/experiment (max score 40):
+- **Baseline:** 32/40 (80%) — numbered steps, bright colors, illegible text
+- **Exp 1 KEEP (87.5%):** Added anti-numbering rule
+- **Exp 2 DISCARD (85%):** Font size rule hurt color compliance
+- **Exp 3 KEEP (92.5%):** Specific hex codes replaced vague "pastel"
+- **Exp 4 DISCARD (92.5%):** Anti-neon rule redundant with hex codes
+- **Exp 5 KEEP (97.5%):** Added worked example with correct formatting
+- **Result:** 80% -> 97.5%, 3 kept / 2 discarded

--- a/.claude/skills/autoresearch/assets/dashboard-template.html
+++ b/.claude/skills/autoresearch/assets/dashboard-template.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Autoresearch Dashboard</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f8f9fa; color: #333; padding: 2rem; }
+  h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+  .subtitle { color: #888; margin-bottom: 1.5rem; }
+  .status { display: inline-block; padding: 0.3rem 0.8rem; border-radius: 20px; font-size: 0.85rem; font-weight: 600; margin-bottom: 1.5rem; }
+  .status.running { background: #e3f2fd; color: #1565c0; }
+  .status.complete { background: #e8f5e9; color: #2e7d32; }
+  .summary { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-bottom: 2rem; }
+  .summary-card { background: #fff; border-radius: 12px; padding: 1.25rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  .summary-card .label { font-size: 0.8rem; color: #888; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 0.25rem; }
+  .summary-card .value { font-size: 1.8rem; font-weight: 700; }
+  .summary-card .value.improved { color: #2e7d32; }
+  .chart-container { background: #fff; border-radius: 12px; padding: 1.5rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); margin-bottom: 2rem; max-height: 350px; }
+  table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08); margin-bottom: 2rem; }
+  th { background: #f1f3f5; text-align: left; padding: 0.75rem 1rem; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 1px; color: #666; }
+  td { padding: 0.75rem 1rem; border-top: 1px solid #eee; font-size: 0.9rem; }
+  .badge { display: inline-block; padding: 0.2rem 0.6rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; }
+  .badge.keep { background: #e8f5e9; color: #2e7d32; }
+  .badge.discard { background: #ffebee; color: #c62828; }
+  .badge.baseline { background: #e3f2fd; color: #1565c0; }
+  .eval-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
+  .eval-card { background: #fff; border-radius: 12px; padding: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  .eval-card .name { font-weight: 600; margin-bottom: 0.5rem; font-size: 0.9rem; }
+  .eval-bar { height: 8px; background: #eee; border-radius: 4px; overflow: hidden; }
+  .eval-bar .fill { height: 100%; border-radius: 4px; transition: width 0.3s; }
+  .eval-rate { font-size: 0.8rem; color: #888; margin-top: 0.25rem; }
+  h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #555; }
+</style>
+</head>
+<body>
+<h1 id="title">Autoresearch Dashboard</h1>
+<p class="subtitle" id="subtitle">Loading...</p>
+<div class="status running" id="status">Loading...</div>
+
+<div class="summary">
+  <div class="summary-card"><div class="label">Baseline</div><div class="value" id="baseline">--</div></div>
+  <div class="summary-card"><div class="label">Best Score</div><div class="value improved" id="best">--</div></div>
+  <div class="summary-card"><div class="label">Experiments</div><div class="value" id="expCount">--</div></div>
+  <div class="summary-card"><div class="label">Keep Rate</div><div class="value" id="keepRate">--</div></div>
+</div>
+
+<div class="chart-container"><canvas id="chart"></canvas></div>
+
+<h2>Per-Eval Breakdown</h2>
+<div class="eval-grid" id="evalGrid"></div>
+
+<h2>Experiment Log</h2>
+<table>
+  <thead><tr><th>#</th><th>Score</th><th>Pass Rate</th><th>Status</th><th>Description</th></tr></thead>
+  <tbody id="expTable"></tbody>
+</table>
+
+<script>
+let chart = null;
+
+async function refresh() {
+  try {
+    const resp = await fetch('results.json?t=' + Date.now());
+    if (!resp.ok) return;
+    const data = await resp.json();
+    render(data);
+  } catch(e) { /* results.json not ready yet */ }
+}
+
+function render(d) {
+  document.getElementById('title').textContent = 'Autoresearch: ' + d.skill_name;
+  document.getElementById('subtitle').textContent = d.status === 'complete' ? 'Optimization complete' : 'Running experiment ' + d.current_experiment + '...';
+  const statusEl = document.getElementById('status');
+  statusEl.textContent = d.status === 'complete' ? 'Complete' : 'Running';
+  statusEl.className = 'status ' + d.status;
+
+  document.getElementById('baseline').textContent = d.baseline_score.toFixed(1) + '%';
+  document.getElementById('best').textContent = d.best_score.toFixed(1) + '%';
+  document.getElementById('expCount').textContent = d.experiments.length - 1; // exclude baseline
+
+  const kept = d.experiments.filter(e => e.status === 'keep').length;
+  const total = d.experiments.length - 1;
+  document.getElementById('keepRate').textContent = total > 0 ? Math.round(kept / total * 100) + '%' : '--';
+
+  // Chart
+  const labels = d.experiments.map(e => e.id === 0 ? 'Base' : '#' + e.id);
+  const scores = d.experiments.map(e => e.pass_rate);
+  const colors = d.experiments.map(e => e.status === 'keep' ? '#4caf50' : e.status === 'baseline' ? '#42a5f5' : '#ef5350');
+
+  if (chart) chart.destroy();
+  chart = new Chart(document.getElementById('chart'), {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [{
+        label: 'Pass Rate %',
+        data: scores,
+        backgroundColor: colors,
+        borderRadius: 6,
+      }]
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      scales: { y: { beginAtZero: true, max: 100, ticks: { callback: v => v + '%' } } },
+      plugins: { legend: { display: false } }
+    }
+  });
+
+  // Eval breakdown
+  const grid = document.getElementById('evalGrid');
+  grid.innerHTML = '';
+  (d.eval_breakdown || []).forEach(ev => {
+    const pct = ev.total > 0 ? Math.round(ev.pass_count / ev.total * 100) : 0;
+    const color = pct >= 90 ? '#4caf50' : pct >= 70 ? '#ff9800' : '#ef5350';
+    grid.innerHTML += `<div class="eval-card"><div class="name">${ev.name}</div><div class="eval-bar"><div class="fill" style="width:${pct}%;background:${color}"></div></div><div class="eval-rate">${ev.pass_count}/${ev.total} (${pct}%)</div></div>`;
+  });
+
+  // Table
+  const tbody = document.getElementById('expTable');
+  tbody.innerHTML = '';
+  d.experiments.forEach(e => {
+    tbody.innerHTML += `<tr><td>${e.id}</td><td>${e.score}/${e.max_score}</td><td>${e.pass_rate.toFixed(1)}%</td><td><span class="badge ${e.status}">${e.status}</span></td><td>${e.description}</td></tr>`;
+  });
+}
+
+refresh();
+setInterval(refresh, 10000);
+</script>
+</body>
+</html>

--- a/.claude/skills/autoresearch/references/eval-guide.md
+++ b/.claude/skills/autoresearch/references/eval-guide.md
@@ -1,0 +1,121 @@
+# Eval Guide
+
+How to write eval criteria that actually improve your skills instead of giving you false confidence.
+
+---
+
+## the golden rule
+
+Every eval must be a yes/no question. Not a scale. Not a vibe check. Binary.
+
+Why: Scales compound variability. If you have 4 evals scored 1-7, your total score has massive variance across runs. Binary evals give you a reliable signal.
+
+---
+
+## good evals vs bad evals
+
+### Text/copy skills (newsletters, tweets, emails, landing pages)
+
+**Bad evals:**
+- "Is the writing good?" (too vague — what's "good"?)
+- "Rate the engagement potential 1-10" (scale = unreliable)
+- "Does it sound like a human?" (subjective, inconsistent scoring)
+
+**Good evals:**
+- "Does the output contain zero phrases from this banned list: [game-changer, here's the kicker, the best part, level up]?" (binary, specific)
+- "Does the opening sentence reference a specific time, place, or sensory detail?" (binary, checkable)
+- "Is the output between 150-400 words?" (binary, measurable)
+- "Does it end with a specific CTA that tells the reader exactly what to do next?" (binary, structural)
+
+### Visual/design skills (diagrams, images, slides)
+
+**Bad evals:**
+- "Does it look professional?" (subjective)
+- "Rate the visual quality 1-5" (scale)
+- "Is the layout good?" (vague)
+
+**Good evals:**
+- "Is all text in the image legible with no truncated or overlapping words?" (binary, specific)
+- "Does the color palette use only soft/pastel tones with no neon, bright red, or high-saturation colors?" (binary, checkable)
+- "Is the layout linear — flowing either left-to-right or top-to-bottom with no scattered elements?" (binary, structural)
+- "Is the image free of numbered steps, ordinals, or sequential numbering?" (binary, specific)
+
+### Code/technical skills (code generation, configs, scripts)
+
+**Bad evals:**
+- "Is the code clean?" (subjective)
+- "Does it follow best practices?" (vague, which best practices?)
+
+**Good evals:**
+- "Does the code run without errors?" (binary, testable — actually execute it)
+- "Does the output contain zero TODO or placeholder comments?" (binary, greppable)
+- "Are all function and variable names descriptive (no single-letter names except loop counters)?" (binary, checkable)
+- "Does the code include error handling for all external calls (API, file I/O, network)?" (binary, structural)
+
+### Document skills (proposals, reports, decks)
+
+**Bad evals:**
+- "Is it comprehensive?" (compared to what?)
+- "Does it address the client's needs?" (too open-ended)
+
+**Good evals:**
+- "Does the document contain all required sections: [list them]?" (binary, structural)
+- "Is every claim backed by a specific number, date, or source?" (binary, checkable)
+- "Is the document under [X] pages/words?" (binary, measurable)
+- "Does the executive summary fit in one paragraph of 3 sentences or fewer?" (binary, countable)
+
+---
+
+## common mistakes
+
+### 1. Too many evals
+More than 6 evals and the skill starts gaming them — it optimizes for passing the test instead of producing good output. Like a student who memorizes answers without understanding the material.
+
+**Fix:** Pick the 3-6 checks that matter most. If everything passes those, the output is probably good.
+
+### 2. Too narrow/rigid
+"Must contain exactly 3 bullet points" or "Must use the word 'because' at least twice" — these create skills that technically pass but produce weird, stilted output.
+
+**Fix:** Evals should check for qualities you care about, not arbitrary structural constraints.
+
+### 3. Overlapping evals
+If eval 1 is "Is the text grammatically correct?" and eval 4 is "Are there any spelling errors?" — these overlap. A grammar fail often includes spelling. You're double-counting.
+
+**Fix:** Each eval should test something distinct.
+
+### 4. Unmeasurable by an agent
+"Would a human find this engaging?" — an agent can't reliably answer this. It'll say "yes" almost every time.
+
+**Fix:** Translate subjective qualities into observable signals. "Engaging" might mean: "Does the first sentence contain a specific claim, story, or question (not a generic statement)?"
+
+---
+
+## writing your evals: the 3-question test
+
+Before finalizing an eval, ask:
+
+1. **Could two different agents score the same output and agree?** If not, the eval is too subjective. Rewrite it.
+2. **Could a skill game this eval without actually improving?** If yes, the eval is too narrow. Broaden it.
+3. **Does this eval test something the user actually cares about?** If not, drop it. Every eval that doesn't matter dilutes the signal from evals that do.
+
+---
+
+## template
+
+Copy this for each eval:
+
+```
+EVAL [N]: [Short name]
+Question: [Yes/no question]
+Pass: [What "yes" looks like — one sentence, specific]
+Fail: [What triggers "no" — one sentence, specific]
+```
+
+Example:
+
+```
+EVAL 1: Text legibility
+Question: Is all text in the output fully legible with no truncated, overlapping, or cut-off words?
+Pass: Every word is complete and readable without squinting or guessing
+Fail: Any word is partially hidden, overlapping another element, or cut off at the edge
+```


### PR DESCRIPTION
## Summary
- Add `autoresearch` skill adapted from [olelehmann100kMRR/autoresearch-skill](https://github.com/olelehmann100kMRR/autoresearch-skill)
- Implements Karpathy's autoresearch methodology for autonomous skill prompt optimization
- Trimmed SKILL.md from 304 to 140 lines (removed redundancy, motivational text, duplicate eval rules)
- Added reusable dashboard template (`assets/dashboard-template.html`) instead of regenerating HTML each run
- Eval-writing guide in `references/eval-guide.md` as single source of truth

## Test plan
- [ ] Invoke `/autoresearch` and verify it prompts for target skill, test inputs, and eval criteria
- [ ] Run against an existing skill (e.g., `create-slide`) with sample evals to verify the experiment loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)