### PR TITLE
fix: reduce events page cache from 24h to 1h

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -24,7 +24,7 @@ async function getPastEvents(): Promise<LumaEvent[]> {
   try {
     const res = await fetch(
       'https://api.lu.ma/calendar/get-items?calendar_api_id=cal-zhuelVReFdNX5xm&period=past&limit=50',
-      { next: { revalidate: 86400 } }
+      { next: { revalidate: 3600 } }
     );
     if (!res.ok) return [];
     const data = await res.json();


### PR DESCRIPTION
## Summary
- Reduced the events page revalidation interval from 24 hours (86400s) to 1 hour (3600s)
- Past events now appear on the page sooner after they finish

## Test plan
- [ ] Verify `/events` page still loads correctly
- [ ] Confirm past events list renders from Lu.ma API

🤖 Generated with [Claude Code](https://claude.com/claude-code)