### PR TITLE
Add vibe coding recap blog post and /commit skill

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: commit
+description: Commit all changes, rebase on main, and create a pull request.
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
+---
+
+# Commit, Rebase & PR
+
+You are a git workflow agent. When invoked, perform the following steps in order. Stop and report if any step fails.
+
+## Arguments
+
+`$ARGUMENTS` — optional commit message override or PR title. If not provided, auto-generate from the changes.
+
+## Steps
+
+### 1. Check Status
+
+Run `git status` (never use `-uall`) and `git diff --stat` to understand what has changed. If there are no changes (no untracked files and no modifications), tell the user there is nothing to commit and stop.
+
+### 2. Stage & Commit
+
+- Review the changes to draft a concise commit message summarizing the "why" not the "what".
+- If `$ARGUMENTS` is provided, use it as the commit message subject line.
+- Do NOT commit files that likely contain secrets (`.env`, credentials, API keys). Warn the user if such files are detected.
+- Stage relevant files by name (prefer specific files over `git add -A`).
+- Commit using a HEREDOC for the message:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<commit message>
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 3. Pull & Rebase
+
+Run `git pull --rebase origin main` to rebase current branch onto the latest main. If there are merge conflicts:
+- Report the conflicting files to the user.
+- Ask how they want to resolve them.
+- Do NOT force-resolve or skip conflicts automatically.
+
+### 4. Push
+
+Push the current branch to the remote:
+
+```bash
+git push -u origin HEAD
+```
+
+If the branch has already been pushed and needs a force push due to the rebase, **ask the user for confirmation** before running `git push --force-with-lease`.
+
+### 5. Create Pull Request
+
+- Determine the PR title: use `$ARGUMENTS` if provided, otherwise derive from the commit(s).
+- Run `git log main..HEAD --oneline` to see all commits that will be in the PR.
+- Create the PR using `gh pr create`:
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points summarizing the changes>
+
+## Test plan
+<checklist of how to verify the changes>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- If a PR already exists for this branch, inform the user and skip creation.
+- Return the PR URL to the user when done.
+
+## Important Rules
+
+- NEVER use `git add -A` or `git add .` — stage files by name.
+- NEVER amend existing commits — always create new ones.
+- NEVER skip hooks (`--no-verify`) or bypass signing.
+- NEVER force push without explicit user confirmation.
+- If any step fails, stop and report the error. Do not retry blindly.

--- a/content/blog/vibe-coding-with-claude-code-march-2026.mdx
+++ b/content/blog/vibe-coding-with-claude-code-march-2026.mdx
@@ -1,0 +1,55 @@
+---
+title: "Vibe Coding with Claude Code — Live Session Recap"
+excerpt: "We went live and built in public with Claude Code. Here's what we covered, what we built, and how you can join the next session."
+date: "2026-03-26"
+author: "Bob Jiang"
+keywords: "Claude Code, vibe coding, build in public, live coding, AI coding, 02Ship, tutorial, beginner"
+---
+
+# Vibe Coding with Claude Code — Live Session Recap
+
+Last night we hosted our first online **vibe coding** session — a casual, live build-in-public stream where we used Claude Code to go from idea to working feature in real time.
+
+Whether you're brand new to Claude Code or use it every day, the goal was the same: watch a real workflow, ask questions, and pick up practical techniques you can use right away.
+
+## Watch the Full Session
+
+If you missed it, the entire session is available as a YouTube replay:
+
+<iframe
+  width="100%"
+  height="400"
+  src="https://www.youtube.com/embed/4D_ypGFIlW8"
+  title="Vibe Coding with Claude Code — Live Session"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+/>
+
+## What We Covered
+
+The session walked through a hands-on Claude Code workflow, covering:
+
+- **Getting started** — setting up Claude Code in the terminal and understanding the basics for anyone new to the tool
+- **Building in public** — working through a real feature from scratch, showing how to iterate with Claude Code step by step
+- **Practical tips** — sharing daily workflow techniques, prompt strategies, and how to get the most out of Claude Code
+- **Q&A** — answering questions from the audience in real time
+
+The key takeaway: vibe coding with Claude Code is less about writing perfect prompts and more about having a conversation with your AI pair programmer. Start with a clear intent, let Claude Code propose an approach, and iterate from there.
+
+## Why Live Sessions?
+
+Building in public removes the polish. You see the real workflow — the false starts, the debugging, the moments where you change direction. That's where the learning happens.
+
+These sessions are designed for non-programmers and beginners who want to see what's actually possible with AI coding tools, without the hype.
+
+## Join the Next Live Session
+
+We're going live again — this time building a website from scratch with Claude Code, turning an idea into a real product step by step.
+
+**[Live] Claude Code Vibe Coding — Build in Public**
+March 27, 2026 | 10:37 AM AEDT | Free on YouTube
+
+**[Register on Luma](https://luma.com/be6zanl8)**
+
+See you there.


### PR DESCRIPTION
## Summary
- Add blog post recapping the March 26 online vibe coding with Claude Code session, with embedded YouTube replay and CTA for the next live stream
- Add `/commit` skill that automates the commit → rebase → push → PR workflow

## Test plan
- [ ] Verify blog post renders correctly at `/blog/vibe-coding-with-claude-code-march-2026`
- [ ] Verify YouTube embed loads and plays
- [ ] Verify Luma CTA link works
- [ ] Verify `/commit` skill appears in available skills list

🤖 Generated with [Claude Code](https://claude.com/claude-code)