### PR TITLE
feat: add Get Involved page

### DIFF
--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from 'next';
+import { Container } from '@/components/ui/Container';
+
+export const metadata: Metadata = {
+  title: 'Get Involved - 02Ship',
+  description:
+    'Join the 02Ship community as a volunteer, speaker, sponsor, or contributor. Help non-programmers learn to build and ship with AI coding tools.',
+  alternates: { canonical: '/get-involved' },
+};
+
+const roles = [
+  {
+    title: 'Speaker',
+    description:
+      'Share your experience building with AI tools. Present at our meetups, workshops, or online events.',
+    icon: (
+      <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Volunteer',
+    description:
+      'Help organize events, mentor learners, create content, or contribute to our open-source projects.',
+    icon: (
+      <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Sponsor',
+    description:
+      'Support our mission to make AI-powered development accessible. Sponsor events, courses, or the platform.',
+    icon: (
+      <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Contributor',
+    description:
+      'Have another idea? We welcome all forms of contribution — content, translations, design, and more.',
+    icon: (
+      <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z" />
+      </svg>
+    ),
+  },
+];
+
+export default function GetInvolvedPage() {
+  return (
+    <div className="py-20">
+      <Container>
+        <div className="mx-auto max-w-2xl text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            Get Involved
+          </h1>
+          <p className="mt-4 text-lg text-gray-600">
+            02Ship is built by the community, for the community. Whether you
+            want to speak, volunteer, sponsor, or contribute in your own way —
+            there&apos;s a place for you.
+          </p>
+        </div>
+
+        <div className="mx-auto mt-16 grid max-w-3xl grid-cols-1 gap-8 sm:grid-cols-2">
+          {roles.map((role) => (
+            <div
+              key={role.title}
+              className="flex flex-col rounded-xl border border-gray-200 p-6 transition-all hover:border-gray-300 hover:shadow-md"
+            >
+              <div className="text-gray-700">{role.icon}</div>
+              <h2 className="mt-4 text-xl font-semibold text-gray-900">
+                {role.title}
+              </h2>
+              <p className="mt-2 text-sm leading-relaxed text-gray-600">
+                {role.description}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mx-auto mt-16 max-w-xl text-center">
+          <h2 className="text-2xl font-bold text-gray-900">
+            Ready to join us?
+          </h2>
+          <p className="mt-3 text-gray-600">
+            Fill out the form below and we&apos;ll get back to you.
+          </p>
+          <a
+            href="https://forms.gle/CuhvaFTHKip9R1At9"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-6 inline-flex items-center gap-2 rounded-lg bg-gray-900 px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-800"
+          >
+            Fill Out the Form
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+            </svg>
+          </a>
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -47,6 +47,9 @@ export function Header() {
               <Link href="/events" className="text-sm font-medium text-gray-700 hover:text-gray-900">
                 Events
               </Link>
+              <Link href="/get-involved" className="text-sm font-medium text-gray-700 hover:text-gray-900">
+                Get Involved
+              </Link>
               <div className="group relative">
                 <button aria-haspopup="true" aria-expanded={false} className="flex items-center gap-1 text-sm font-medium text-gray-700 hover:text-gray-900">
                   About
@@ -134,6 +137,13 @@ export function Header() {
                 onClick={() => setMobileMenuOpen(false)}
               >
                 Events
+              </Link>
+              <Link
+                href="/get-involved"
+                className="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                Get Involved
               </Link>
               <div className="pt-4">
                 <p className="px-3 text-xs font-semibold uppercase tracking-wider text-gray-500">


### PR DESCRIPTION
## Summary
- Add new `/get-involved` page with role cards for speakers, volunteers, sponsors, and contributors
- Link to Google Form (https://forms.gle/CuhvaFTHKip9R1At9) as the CTA
- Add "Get Involved" to top-level navigation (desktop and mobile) in Header

## Test plan
- [ ] Visit `/get-involved` and verify the page renders with 4 role cards
- [ ] Click "Fill Out the Form" button and confirm it opens the Google Form in a new tab
- [ ] Verify "Get Involved" appears in the desktop nav between "Events" and the "About" dropdown
- [ ] Open mobile menu and verify "Get Involved" link appears and navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)