### PR TITLE
Reposition 02Ship as Claude builder community with Project Hub & Cohort

### DIFF
--- a/.github/ISSUE_TEMPLATE/ship-submission.yml
+++ b/.github/ISSUE_TEMPLATE/ship-submission.yml
@@ -65,8 +65,8 @@ body:
       label: Cohort (optional)
       description: Where did you build/present this?
       options:
-        - Cohort #1
-        - Cohort #2
+        - "Cohort #1 (Mar 2026)"
+        - "Cohort #2 (Apr 2026)"
         - Meetup Demo
         - Independent Build
 


### PR DESCRIPTION
## Summary
- Add Project Hub (/ships) with listing and detail pages for community project showcases
- Add Cohort program page (/ship-weeks) for 2-week build sprints with timeline and apply CTA
- Reposition homepage, nav, footer, and metadata from beginner learning portal to practitioner-focused Claude community
- Add GitHub issue template for community project submissions
- Add Ship type, content loader, sitemap entries, and seed content (02Ship as first project)

## Test plan
- [ ] Navigate to /ships — shows project listing with 02Ship card
- [ ] Navigate to /ships/02ship — shows detail page with content, links, tags
- [ ] Navigate to /ship-weeks — shows cohort program page with timeline
- [ ] Homepage shows new messaging, stats bar, and community-focused CTAs
- [ ] Nav shows Ships dropdown (Project Hub, Next Cohort) between Get Involved and About
- [ ] Footer shows Project Hub and Cohort links under Build column
- [ ] Sitemap includes /ships, /ship-weeks, and /ships/02ship
- [ ] GitHub issue template renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)