### PR TITLE
feat: community lightning talk voting tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
-# Site Configuration
+# Vercel KV (auto-populated by `vercel env pull .env.local` after linking KV)
+KV_REST_API_URL=
+KV_REST_API_TOKEN=
+
+# Lightning-talk voting admin access (32+ random bytes recommended)
+ADMIN_TOKEN=
+
+# Optional — used by src/app/layout.tsx and sitemap
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # Future: Supabase

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,6 +25,20 @@ jobs:
 
       - name: Run e2e tests
         run: npm run test:e2e
+        env:
+          # Supabase vars must be non-empty so `next build` does not crash at prerender.
+          # If NEXT_PUBLIC_SUPABASE_URL is configured as a repo secret, it wins;
+          # otherwise fall back to a harmless stub that lets the build finish.
+          # Specs that actually exercise /login, /signup, or /dashboard need the real
+          # values to pass.
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://stub.supabase.co' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'stub-anon-key-for-ci-build' }}
+          # Voting feature env. Empty when secrets are not set; the voting spec
+          # uses test.skip() to gracefully skip itself in that case.
+          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
+          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          E2E_ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,15 +26,8 @@ jobs:
       - name: Run e2e tests
         run: npm run test:e2e
         env:
-          # Supabase vars must be non-empty so `next build` does not crash at prerender.
-          # If NEXT_PUBLIC_SUPABASE_URL is configured as a repo secret, it wins;
-          # otherwise fall back to a harmless stub that lets the build finish.
-          # Specs that actually exercise /login, /signup, or /dashboard need the real
-          # values to pass.
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://stub.supabase.co' }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'stub-anon-key-for-ci-build' }}
-          # Voting feature env. Empty when secrets are not set; the voting spec
-          # uses test.skip() to gracefully skip itself in that case.
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ next-env.d.ts
 content/courses/claude-basics/video-gen/*
 content/courses/*/video-gen/output/
 .gstack/
+
+# worktrees
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,21 @@ Requires: `GOOGLE_TTS_API_KEY` in `.env.local`, `ffmpeg`/`ffprobe` on PATH, Play
 - Theme config: `tailwind.config.ts` (CSS variable-based colors, typography plugin)
 - Root layout: `src/app/layout.tsx` (metadata, GA, JSON-LD)
 - Video renderer: `agents/video-gen/generate-lesson-video.mjs`
+
+## Skill routing
+
+When the user's request matches an available skill, ALWAYS invoke it using the Skill
+tool as your FIRST action. Do NOT answer directly, do NOT use other tools first.
+The skill has specialized workflows that produce better results than ad-hoc answers.
+
+Key routing rules:
+- Product ideas, "is this worth building", brainstorming → invoke office-hours
+- Bugs, errors, "why is this broken", 500 errors → invoke investigate
+- Ship, deploy, push, create PR → invoke ship
+- QA, test the site, find bugs → invoke qa
+- Code review, check my diff → invoke review
+- Update docs after shipping → invoke document-release
+- Weekly retro → invoke retro
+- Design system, brand → invoke design-consultation
+- Visual audit, design polish → invoke design-review
+- Architecture review → invoke plan-eng-review

--- a/README.md
+++ b/README.md
@@ -130,3 +130,18 @@ Post content here...
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details
+
+## Lightning Talk Voting
+
+Single-event submission + voting tool under `/submit`, `/vote`, and `/admin`.
+
+**Required env vars** (see `.env.example`):
+
+- `KV_REST_API_URL`, `KV_REST_API_TOKEN` — Vercel KV (run `vercel env pull .env.local` after linking the KV store)
+- `ADMIN_TOKEN` — used for admin login and session-cookie signing; generate 32+ random bytes
+
+**Event config:** edit `content/events/lightning-talk.json` and redeploy. Runtime edits are not supported.
+
+**QR codes:** generate PNGs from the production URLs (`/submit` and `/vote`) using any external QR generator, then drop them into `public/events/` as `lightning-talk-qr-submit.png` and `lightning-talk-qr-vote.png`. Regenerate if the production domain changes.
+
+**After the event:** keep `content/events/lightning-talk.json` as an archive; purge KV data with a one-off script if desired.

--- a/content/events/lightning-talk.json
+++ b/content/events/lightning-talk.json
@@ -1,0 +1,11 @@
+{
+  "slug": "lightning-talk",
+  "name": "Community Lightning Talks — April 2026",
+  "submissionOpensAt": "2026-04-15T00:00:00Z",
+  "submissionClosesAt": "2026-04-25T23:59:00Z",
+  "votingOpensAt": "2026-04-20T00:00:00Z",
+  "votingClosesAt": "2026-04-27T23:59:00Z",
+  "voteLimit": 3,
+  "submissionRateLimitPerCookie24h": 3,
+  "contactRule": "handle-or-contact"
+}

--- a/content/events/lightning-talk.json
+++ b/content/events/lightning-talk.json
@@ -3,7 +3,6 @@
   "name": "Community Lightning Talks — April 2026",
   "submissionOpensAt": "2026-04-15T00:00:00Z",
   "submissionClosesAt": "2026-04-25T23:59:00Z",
-  "votingOpensAt": "2026-04-20T00:00:00Z",
   "votingClosesAt": "2026-04-27T23:59:00Z",
   "voteLimit": 3,
   "submissionRateLimitPerCookie24h": 3,

--- a/docs/superpowers/plans/2026-04-19-lightning-talk-voting.md
+++ b/docs/superpowers/plans/2026-04-19-lightning-talk-voting.md
@@ -1,0 +1,2334 @@
+# Lightning Talk Voting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the community lightning-talk submission and voting feature exactly as specified in `docs/superpowers/specs/2026-04-19-lightning-talk-voting-design.md`.
+
+**Architecture:** Single-event, mobile-first, QR-driven flow inside the existing Next.js 14 App Router app. Public pages + thin JSON APIs. Mutable state in Vercel KV (`@vercel/kv`). Event config committed to the repo. Anonymous voter identity via an `httpOnly` UUID cookie seeded by middleware. Admin access via a signed session cookie backed by `ADMIN_TOKEN`.
+
+**Tech Stack:** Next.js 14 App Router, TypeScript strict, Tailwind, `@vercel/kv`, `zod` (already in deps), `crypto` (node built-in), Vitest for unit tests, Playwright for the one smoke spec.
+
+---
+
+## Pre-flight
+
+Before starting, confirm:
+
+1. You are working on a dedicated branch. A stale `feat/community-voting` branch exists from a prior Supabase attempt — do NOT build on it. Start from `main` on a new branch, e.g. `feat/lightning-talk-voting`.
+2. Vercel KV has been provisioned for the project (so `KV_REST_API_URL` and `KV_REST_API_TOKEN` are available locally via `vercel env pull .env.local` when you want to exercise KV in dev). Unit tests never touch KV and work without it.
+3. The spec file path: `docs/superpowers/specs/2026-04-19-lightning-talk-voting-design.md`. Re-read it if anything below is ambiguous — the spec wins.
+
+## File structure
+
+**Create:**
+
+| Path | Responsibility |
+|---|---|
+| `content/events/lightning-talk.json` | Single-event config (windows, limits, rules) |
+| `src/types/event.ts` | `EventConfig` type |
+| `src/types/voting.ts` | `Submission`, `SubmissionStatus`, `Ballot`, `AdminSession` types |
+| `src/lib/voting.ts` | Pure helpers (`isWithinWindow`, `validateBallot`, `sameCanonicalBallot`, `tallyVotes`, `shuffleWithSeed`, `getEventConfig`) + KV access (`createSubmission`, `listSubmissions`, `setSubmissionStatus`, `getBallot`, `writeBallot`, `voterCount`, `incrSubmitRate`, `getSubmitRate`) |
+| `src/lib/admin.ts` | `constantTimeTokenMatch`, `signSession`, `verifySession`, `newSessionCookieValue`, `readAdminSession` |
+| `src/lib/__tests__/voting.test.ts` | Unit tests for pure helpers in `voting.ts` |
+| `src/lib/__tests__/admin.test.ts` | Unit tests for pure helpers in `admin.ts` |
+| `src/middleware.ts` | Seeds `zts_voter` cookie on public + API paths |
+| `src/app/submit/page.tsx` | Server page for QR 1 |
+| `src/app/submit/SubmissionForm.tsx` | Client form component |
+| `src/app/vote/page.tsx` | Server page for QR 2 |
+| `src/app/vote/VoteClient.tsx` | Client selection UI |
+| `src/app/admin/page.tsx` | Landing / token-entry |
+| `src/app/admin/AdminLoginForm.tsx` | Client form that POSTs to `/api/admin/session` |
+| `src/app/admin/submissions/page.tsx` | Moderation queue |
+| `src/app/admin/submissions/SubmissionActions.tsx` | Client action buttons (PATCH) |
+| `src/app/admin/results/page.tsx` | Ranked tally |
+| `src/app/admin/results/ResultsExport.tsx` | Client CSV download button |
+| `src/app/api/submissions/route.ts` | POST create submission |
+| `src/app/api/votes/route.ts` | POST ballot |
+| `src/app/api/admin/session/route.ts` | POST login |
+| `src/app/api/admin/logout/route.ts` | POST clear session |
+| `src/app/api/admin/submissions/route.ts` | GET + PATCH submissions |
+| `src/app/api/admin/results/route.ts` | GET tally |
+| `e2e/lightning-talk-voting.spec.ts` | Playwright smoke |
+| `public/events/.gitkeep` | Placeholder; real QRs are tracked PNGs added manually |
+
+**Modify:**
+
+| Path | Change |
+|---|---|
+| `package.json` | Add `@vercel/kv` dependency |
+| `.env.example` (create if absent) | Document `ADMIN_TOKEN`, `KV_REST_API_URL`, `KV_REST_API_TOKEN` |
+| `README.md` | Short "Lightning Talk Voting" section with env vars + QR generation note |
+
+---
+
+## Phase 0 — Foundation
+
+### Task 0.1: Install `@vercel/kv` and add env example
+
+**Files:**
+- Modify: `package.json`
+- Create: `.env.example`
+
+- [ ] **Step 1: Install the dependency**
+
+Run:
+```bash
+npm install @vercel/kv
+```
+
+Expected: `package.json` gains `"@vercel/kv": "^<version>"` under `dependencies`, `package-lock.json` updates.
+
+- [ ] **Step 2: Create `.env.example` with required vars**
+
+Create `.env.example`:
+```bash
+# Vercel KV (auto-populated by `vercel env pull .env.local` after linking KV)
+KV_REST_API_URL=
+KV_REST_API_TOKEN=
+
+# Lightning-talk voting admin access (32+ random bytes recommended)
+ADMIN_TOKEN=
+
+# Optional — used by src/app/layout.tsx and sitemap
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+```
+
+- [ ] **Step 3: Verify install did not break typecheck**
+
+Run:
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json .env.example
+git commit -m "feat(voting): add @vercel/kv dep and env example"
+```
+
+---
+
+### Task 0.2: Event config file and types
+
+**Files:**
+- Create: `content/events/lightning-talk.json`
+- Create: `src/types/event.ts`
+- Create: `src/types/voting.ts`
+
+- [ ] **Step 1: Create the event config**
+
+Create `content/events/lightning-talk.json`:
+```json
+{
+  "slug": "lightning-talk",
+  "name": "Community Lightning Talks — April 2026",
+  "submissionOpensAt": "2026-04-15T00:00:00Z",
+  "submissionClosesAt": "2026-04-25T23:59:00Z",
+  "votingOpensAt": "2026-04-20T00:00:00Z",
+  "votingClosesAt": "2026-04-27T23:59:00Z",
+  "voteLimit": 3,
+  "submissionRateLimitPerCookie24h": 3,
+  "contactRule": "handle-or-contact"
+}
+```
+
+- [ ] **Step 2: Create event type**
+
+Create `src/types/event.ts`:
+```ts
+export type ContactRule = 'handle-or-contact';
+
+export interface EventConfig {
+  slug: string;
+  name: string;
+  submissionOpensAt: string;
+  submissionClosesAt: string;
+  votingOpensAt: string;
+  votingClosesAt: string;
+  voteLimit: number;
+  submissionRateLimitPerCookie24h: number;
+  contactRule: ContactRule;
+}
+```
+
+- [ ] **Step 3: Create voting/submission types**
+
+Create `src/types/voting.ts`:
+```ts
+export type SubmissionStatus = 'pending' | 'approved' | 'rejected';
+
+export interface Submission {
+  id: string;
+  event: string;
+  speakerName: string;
+  handle?: string;
+  contact?: string;
+  title: string;
+  intro: string;
+  tag?: string;
+  status: SubmissionStatus;
+  createdAt: string;
+}
+
+export interface Ballot {
+  submissionIds: string[];
+  submittedAt: string;
+}
+
+export interface AdminSession {
+  expMs: number;
+}
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run:
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add content/events/lightning-talk.json src/types/event.ts src/types/voting.ts
+git commit -m "feat(voting): add event config + core types"
+```
+
+---
+
+## Phase 1 — Pure helpers with unit tests
+
+### Task 1.1: Voting pure helpers (TDD)
+
+**Files:**
+- Create: `src/lib/voting.ts`
+- Test: `src/lib/__tests__/voting.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/lib/__tests__/voting.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  isWithinWindow,
+  validateBallot,
+  sameCanonicalBallot,
+  tallyVotes,
+  shuffleWithSeed,
+} from '@/lib/voting';
+
+describe('isWithinWindow', () => {
+  const opens = '2026-04-20T00:00:00Z';
+  const closes = '2026-04-27T00:00:00Z';
+
+  it('is false before opens', () => {
+    expect(isWithinWindow(opens, closes, new Date('2026-04-19T23:59:59Z'))).toBe(false);
+  });
+  it('is true at opens', () => {
+    expect(isWithinWindow(opens, closes, new Date('2026-04-20T00:00:00Z'))).toBe(true);
+  });
+  it('is true mid-window', () => {
+    expect(isWithinWindow(opens, closes, new Date('2026-04-23T12:00:00Z'))).toBe(true);
+  });
+  it('is false at closes (exclusive)', () => {
+    expect(isWithinWindow(opens, closes, new Date('2026-04-27T00:00:00Z'))).toBe(false);
+  });
+});
+
+describe('validateBallot', () => {
+  const approved = new Set(['a', 'b', 'c', 'd']);
+
+  it('rejects empty array', () => {
+    expect(validateBallot([], 3, approved)).toEqual({ ok: false, error: 'validation' });
+  });
+  it('rejects over limit', () => {
+    expect(validateBallot(['a', 'b', 'c', 'd'], 3, approved)).toEqual({ ok: false, error: 'validation' });
+  });
+  it('rejects duplicates', () => {
+    expect(validateBallot(['a', 'a'], 3, approved)).toEqual({ ok: false, error: 'validation' });
+  });
+  it('rejects unknown id', () => {
+    expect(validateBallot(['a', 'z'], 3, approved)).toEqual({ ok: false, error: 'unknown-submission' });
+  });
+  it('accepts a valid ballot', () => {
+    expect(validateBallot(['a', 'b'], 3, approved)).toEqual({ ok: true });
+  });
+});
+
+describe('sameCanonicalBallot', () => {
+  it('is true for same ids in same order', () => {
+    expect(sameCanonicalBallot(['a', 'b'], ['a', 'b'])).toBe(true);
+  });
+  it('is true for same ids different order', () => {
+    expect(sameCanonicalBallot(['a', 'b', 'c'], ['c', 'a', 'b'])).toBe(true);
+  });
+  it('is false for different lengths', () => {
+    expect(sameCanonicalBallot(['a'], ['a', 'b'])).toBe(false);
+  });
+  it('is false for different ids', () => {
+    expect(sameCanonicalBallot(['a', 'b'], ['a', 'c'])).toBe(false);
+  });
+});
+
+describe('tallyVotes', () => {
+  const approved = new Set(['a', 'b', 'c']);
+
+  it('counts approved ids only', () => {
+    const ballots = [
+      { submissionIds: ['a', 'b'] },
+      { submissionIds: ['a', 'c'] },
+      { submissionIds: ['a', 'd'] }, // d is not approved -> ignored
+    ];
+    const counts = tallyVotes(ballots, approved);
+    expect(counts.get('a')).toBe(3);
+    expect(counts.get('b')).toBe(1);
+    expect(counts.get('c')).toBe(1);
+    expect(counts.has('d')).toBe(false);
+  });
+
+  it('returns an empty map when no ballots', () => {
+    expect(tallyVotes([], approved).size).toBe(0);
+  });
+});
+
+describe('shuffleWithSeed', () => {
+  it('is deterministic for the same seed', () => {
+    const a = shuffleWithSeed(['x', 'y', 'z', 'w', 'v'], 'seed-1');
+    const b = shuffleWithSeed(['x', 'y', 'z', 'w', 'v'], 'seed-1');
+    expect(a).toEqual(b);
+  });
+  it('differs across seeds', () => {
+    const a = shuffleWithSeed(['x', 'y', 'z', 'w', 'v'], 'seed-1');
+    const b = shuffleWithSeed(['x', 'y', 'z', 'w', 'v'], 'seed-2');
+    expect(a).not.toEqual(b);
+  });
+  it('preserves the multiset', () => {
+    const input = ['x', 'y', 'z', 'w', 'v'];
+    const out = shuffleWithSeed(input, 'seed-3');
+    expect(out.sort()).toEqual([...input].sort());
+  });
+  it('does not mutate input', () => {
+    const input = ['x', 'y', 'z'];
+    shuffleWithSeed(input, 's');
+    expect(input).toEqual(['x', 'y', 'z']);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — they must fail**
+
+Run:
+```bash
+npx vitest run src/lib/__tests__/voting.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the pure helpers**
+
+Create `src/lib/voting.ts`:
+```ts
+import fs from 'fs/promises';
+import path from 'path';
+import type { EventConfig } from '@/types/event';
+
+export async function getEventConfig(slug = 'lightning-talk'): Promise<EventConfig> {
+  const file = path.join(process.cwd(), 'content', 'events', `${slug}.json`);
+  const raw = await fs.readFile(file, 'utf-8');
+  return JSON.parse(raw) as EventConfig;
+}
+
+export function isWithinWindow(opens: string, closes: string, now: Date): boolean {
+  const o = new Date(opens).getTime();
+  const c = new Date(closes).getTime();
+  const n = now.getTime();
+  return n >= o && n < c;
+}
+
+export type BallotValidation =
+  | { ok: true }
+  | { ok: false; error: 'validation' | 'unknown-submission' };
+
+export function validateBallot(
+  submissionIds: unknown,
+  voteLimit: number,
+  approvedIds: Set<string>
+): BallotValidation {
+  if (!Array.isArray(submissionIds)) return { ok: false, error: 'validation' };
+  if (submissionIds.length < 1 || submissionIds.length > voteLimit) {
+    return { ok: false, error: 'validation' };
+  }
+  const seen = new Set<string>();
+  for (const id of submissionIds) {
+    if (typeof id !== 'string' || id.length === 0) return { ok: false, error: 'validation' };
+    if (seen.has(id)) return { ok: false, error: 'validation' };
+    seen.add(id);
+  }
+  for (const id of submissionIds as string[]) {
+    if (!approvedIds.has(id)) return { ok: false, error: 'unknown-submission' };
+  }
+  return { ok: true };
+}
+
+export function sameCanonicalBallot(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const A = [...a].sort();
+  const B = [...b].sort();
+  for (let i = 0; i < A.length; i++) if (A[i] !== B[i]) return false;
+  return true;
+}
+
+export function tallyVotes(
+  ballots: Array<{ submissionIds: string[] }>,
+  approvedIds: Set<string>
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const b of ballots) {
+    for (const id of b.submissionIds) {
+      if (approvedIds.has(id)) counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+function xmur3(str: string): () => number {
+  let h = 1779033703 ^ str.length;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return () => {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    h ^= h >>> 16;
+    return (h >>> 0) / 4294967296;
+  };
+}
+
+export function shuffleWithSeed<T>(items: T[], seed: string): T[] {
+  const rand = xmur3(seed);
+  const arr = [...items];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+```
+
+- [ ] **Step 4: Run tests — they must pass**
+
+Run:
+```bash
+npx vitest run src/lib/__tests__/voting.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/voting.ts src/lib/__tests__/voting.test.ts
+git commit -m "feat(voting): pure helpers with unit tests"
+```
+
+---
+
+### Task 1.2: Admin auth pure helpers (TDD)
+
+**Files:**
+- Create: `src/lib/admin.ts`
+- Test: `src/lib/__tests__/admin.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/lib/__tests__/admin.test.ts`:
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const SECRET = 'a'.repeat(48);
+
+beforeEach(() => {
+  process.env.ADMIN_TOKEN = SECRET;
+});
+
+async function load() {
+  return await import('@/lib/admin');
+}
+
+describe('constantTimeTokenMatch', () => {
+  it('matches the configured token', async () => {
+    const { constantTimeTokenMatch } = await load();
+    expect(constantTimeTokenMatch(SECRET)).toBe(true);
+  });
+  it('rejects a different same-length token', async () => {
+    const { constantTimeTokenMatch } = await load();
+    expect(constantTimeTokenMatch('b'.repeat(48))).toBe(false);
+  });
+  it('rejects a shorter token', async () => {
+    const { constantTimeTokenMatch } = await load();
+    expect(constantTimeTokenMatch('short')).toBe(false);
+  });
+  it('rejects when ADMIN_TOKEN is unset', async () => {
+    delete process.env.ADMIN_TOKEN;
+    const { constantTimeTokenMatch } = await load();
+    expect(constantTimeTokenMatch(SECRET)).toBe(false);
+  });
+});
+
+describe('signSession / verifySession', () => {
+  it('verifies a freshly signed session', async () => {
+    const { signSession, verifySession } = await load();
+    const now = 1_700_000_000_000;
+    const exp = now + 60_000;
+    const value = signSession(exp);
+    expect(verifySession(value, now)).toBe(true);
+  });
+  it('rejects an expired session', async () => {
+    const { signSession, verifySession } = await load();
+    const now = 1_700_000_000_000;
+    const exp = now - 1;
+    expect(verifySession(signSession(exp), now)).toBe(false);
+  });
+  it('rejects a tampered signature', async () => {
+    const { signSession, verifySession } = await load();
+    const now = 1_700_000_000_000;
+    const value = signSession(now + 60_000);
+    const tampered = value.slice(0, -1) + (value.slice(-1) === 'a' ? 'b' : 'a');
+    expect(verifySession(tampered, now)).toBe(false);
+  });
+  it('rejects a malformed value', async () => {
+    const { verifySession } = await load();
+    expect(verifySession('not-a-session', Date.now())).toBe(false);
+    expect(verifySession(undefined, Date.now())).toBe(false);
+  });
+});
+
+describe('newSessionCookieValue', () => {
+  it('produces a value that verifies right now', async () => {
+    const { newSessionCookieValue, verifySession } = await load();
+    const now = Date.now();
+    const { value, expiresAt } = newSessionCookieValue(now);
+    expect(verifySession(value, now)).toBe(true);
+    expect(expiresAt.getTime()).toBeGreaterThan(now);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — they must fail**
+
+Run:
+```bash
+npx vitest run src/lib/__tests__/admin.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `src/lib/admin.ts`:
+```ts
+import crypto from 'crypto';
+
+const SESSION_TTL_MS = 8 * 60 * 60 * 1000;
+export const ADMIN_SESSION_COOKIE = 'zts_admin';
+
+function secret(): string {
+  return process.env.ADMIN_TOKEN ?? '';
+}
+
+export function constantTimeTokenMatch(provided: string): boolean {
+  const expected = secret();
+  if (!expected) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    // keep timing stable even when lengths differ
+    crypto.timingSafeEqual(Buffer.alloc(b.length), b);
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+}
+
+export function signSession(expMs: number): string {
+  const payload = String(expMs);
+  const hmac = crypto.createHmac('sha256', secret()).update(payload).digest('base64url');
+  return `${payload}.${hmac}`;
+}
+
+export function verifySession(value: string | undefined, nowMs: number): boolean {
+  if (!value) return false;
+  const dot = value.indexOf('.');
+  if (dot <= 0) return false;
+  const payload = value.slice(0, dot);
+  const sig = value.slice(dot + 1);
+  const expMs = Number(payload);
+  if (!Number.isFinite(expMs) || expMs < nowMs) return false;
+  const expected = crypto.createHmac('sha256', secret()).update(payload).digest('base64url');
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+export interface NewSession {
+  value: string;
+  expiresAt: Date;
+}
+
+export function newSessionCookieValue(nowMs: number = Date.now()): NewSession {
+  const expMs = nowMs + SESSION_TTL_MS;
+  return { value: signSession(expMs), expiresAt: new Date(expMs) };
+}
+```
+
+- [ ] **Step 4: Run tests — they must pass**
+
+Run:
+```bash
+npx vitest run src/lib/__tests__/admin.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/admin.ts src/lib/__tests__/admin.test.ts
+git commit -m "feat(voting): admin token + signed session helpers"
+```
+
+---
+
+## Phase 2 — KV layer
+
+### Task 2.1: Submission + ballot + rate-limit KV helpers
+
+**Files:**
+- Modify: `src/lib/voting.ts`
+
+- [ ] **Step 1: Append KV helpers to `voting.ts`**
+
+Append the following exports to `src/lib/voting.ts` (keep the existing pure helpers above):
+```ts
+import { kv } from '@vercel/kv';
+import type { Submission, SubmissionStatus, Ballot } from '@/types/voting';
+
+const submissionKey = (id: string) => `submission:${id}`;
+const submissionsSetKey = (event: string) => `submissions:set:${event}`;
+const voteKey = (event: string, voter: string) => `vote:${event}:${voter}`;
+const votersSetKey = (event: string) => `voters:set:${event}`;
+const submitRateKey = (event: string, cookie: string) => `submit-rate:${event}:${cookie}`;
+
+export async function createSubmission(input: Omit<Submission, 'id' | 'status' | 'createdAt'>): Promise<Submission> {
+  const id = crypto.randomUUID();
+  const submission: Submission = {
+    ...input,
+    id,
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+  };
+  await kv.set(submissionKey(id), submission);
+  await kv.sadd(submissionsSetKey(input.event), id);
+  return submission;
+}
+
+export async function getSubmission(id: string): Promise<Submission | null> {
+  return (await kv.get<Submission>(submissionKey(id))) ?? null;
+}
+
+export async function listSubmissions(event: string): Promise<Submission[]> {
+  const ids = (await kv.smembers(submissionsSetKey(event))) as string[];
+  if (ids.length === 0) return [];
+  const results = await Promise.all(ids.map((id) => kv.get<Submission>(submissionKey(id))));
+  return results.filter((s): s is Submission => s !== null);
+}
+
+export async function setSubmissionStatus(id: string, status: SubmissionStatus): Promise<void> {
+  const current = await getSubmission(id);
+  if (!current) throw new Error(`submission ${id} not found`);
+  await kv.set(submissionKey(id), { ...current, status });
+}
+
+export async function getBallot(event: string, voter: string): Promise<Ballot | null> {
+  return (await kv.get<Ballot>(voteKey(event, voter))) ?? null;
+}
+
+export async function writeBallot(event: string, voter: string, ballot: Ballot): Promise<void> {
+  await kv.set(voteKey(event, voter), ballot);
+  await kv.sadd(votersSetKey(event), voter);
+}
+
+export async function voterCount(event: string): Promise<number> {
+  return (await kv.scard(votersSetKey(event))) as number;
+}
+
+export async function listBallots(event: string): Promise<Ballot[]> {
+  const voters = (await kv.smembers(votersSetKey(event))) as string[];
+  if (voters.length === 0) return [];
+  const results = await Promise.all(voters.map((v) => kv.get<Ballot>(voteKey(event, v))));
+  return results.filter((b): b is Ballot => b !== null);
+}
+
+export async function getSubmitRate(event: string, cookie: string): Promise<number> {
+  return (await kv.get<number>(submitRateKey(event, cookie))) ?? 0;
+}
+
+export async function incrSubmitRate(event: string, cookie: string): Promise<number> {
+  const key = submitRateKey(event, cookie);
+  const n = (await kv.incr(key)) as number;
+  if (n === 1) await kv.expire(key, 86400);
+  return n;
+}
+```
+
+- [ ] **Step 2: Typecheck and lint**
+
+Run:
+```bash
+npx tsc --noEmit && npm run lint
+```
+
+Expected: no errors. If `@vercel/kv` typings complain, verify Task 0.1 installed it.
+
+- [ ] **Step 3: Run existing unit tests — still pass**
+
+Run:
+```bash
+npx vitest run
+```
+
+Expected: all pass (KV code paths are not exercised by unit tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/voting.ts
+git commit -m "feat(voting): KV helpers for submissions, ballots, rate limit"
+```
+
+---
+
+## Phase 3 — Middleware (voter cookie)
+
+### Task 3.1: `zts_voter` middleware
+
+**Files:**
+- Create: `src/middleware.ts`
+
+- [ ] **Step 1: Create middleware**
+
+Create `src/middleware.ts`:
+```ts
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export const VOTER_COOKIE = 'zts_voter';
+
+export function middleware(req: NextRequest) {
+  const res = NextResponse.next();
+  if (!req.cookies.get(VOTER_COOKIE)) {
+    res.cookies.set({
+      name: VOTER_COOKIE,
+      value: crypto.randomUUID(),
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 365,
+    });
+  }
+  return res;
+}
+
+export const config = {
+  matcher: ['/submit', '/vote', '/api/submissions', '/api/votes'],
+};
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run:
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: build succeeds. Warnings are fine as long as compilation passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/middleware.ts
+git commit -m "feat(voting): middleware seeds zts_voter cookie"
+```
+
+---
+
+## Phase 4 — Submissions flow
+
+### Task 4.1: `POST /api/submissions`
+
+**Files:**
+- Create: `src/app/api/submissions/route.ts`
+
+- [ ] **Step 1: Implement route**
+
+Create `src/app/api/submissions/route.ts`:
+```ts
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import { VOTER_COOKIE } from '@/middleware';
+import {
+  createSubmission,
+  getEventConfig,
+  getSubmitRate,
+  incrSubmitRate,
+  isWithinWindow,
+} from '@/lib/voting';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  speakerName: z.string().trim().min(1),
+  handle: z.string().trim().optional(),
+  contact: z.string().trim().optional(),
+  title: z.string().trim().min(1).max(80),
+  intro: z.string().trim().min(1).max(500),
+  tag: z.string().trim().optional(),
+  consent: z.literal(true),
+});
+
+export async function POST(req: Request) {
+  const voter = cookies().get(VOTER_COOKIE)?.value;
+  if (!voter) {
+    return NextResponse.json({ ok: false, error: 'cookies-required' }, { status: 400 });
+  }
+
+  const event = await getEventConfig();
+  if (!isWithinWindow(event.submissionOpensAt, event.submissionClosesAt, new Date())) {
+    return NextResponse.json({ ok: false, error: 'closed' }, { status: 400 });
+  }
+
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  }
+  const { handle, contact } = parsed.data;
+  if (!(handle && handle.length > 0) && !(contact && contact.length > 0)) {
+    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  }
+
+  const count = await getSubmitRate(event.slug, voter);
+  if (count >= event.submissionRateLimitPerCookie24h) {
+    return NextResponse.json({ ok: false, error: 'rate-limited' }, { status: 429 });
+  }
+
+  const submission = await createSubmission({
+    event: event.slug,
+    speakerName: parsed.data.speakerName,
+    handle,
+    contact,
+    title: parsed.data.title,
+    intro: parsed.data.intro,
+    tag: parsed.data.tag,
+  });
+  await incrSubmitRate(event.slug, voter);
+
+  return NextResponse.json({ ok: true, id: submission.id });
+}
+```
+
+- [ ] **Step 2: Typecheck + build**
+
+Run:
+```bash
+npx tsc --noEmit && npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/submissions/route.ts
+git commit -m "feat(voting): POST /api/submissions"
+```
+
+---
+
+### Task 4.2: `/submit` page + `<SubmissionForm />`
+
+**Files:**
+- Create: `src/app/submit/page.tsx`
+- Create: `src/app/submit/SubmissionForm.tsx`
+
+- [ ] **Step 1: Create the client form**
+
+Create `src/app/submit/SubmissionForm.tsx`:
+```tsx
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  disabled: boolean;
+  submissionClosesAt: string;
+  eventName: string;
+}
+
+type Status = 'idle' | 'submitting' | 'success' | 'error';
+
+export function SubmissionForm({ disabled, submissionClosesAt, eventName }: Props) {
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (disabled) return;
+    setStatus('submitting');
+    const fd = new FormData(e.currentTarget);
+    const body = {
+      speakerName: String(fd.get('speakerName') ?? '').trim(),
+      handle: String(fd.get('handle') ?? '').trim() || undefined,
+      contact: String(fd.get('contact') ?? '').trim() || undefined,
+      title: String(fd.get('title') ?? '').trim(),
+      intro: String(fd.get('intro') ?? '').trim(),
+      tag: String(fd.get('tag') ?? '').trim() || undefined,
+      consent: fd.get('consent') === 'on',
+    };
+    const res = await fetch('/api/submissions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.ok) {
+      setStatus('success');
+      return;
+    }
+    setStatus('error');
+    switch (data.error) {
+      case 'closed':
+        setErrorMsg('Submissions are closed.');
+        break;
+      case 'rate-limited':
+        setErrorMsg("You've reached the limit of submissions from this browser in 24 hours.");
+        break;
+      case 'cookies-required':
+        setErrorMsg('Please enable cookies and reload before submitting.');
+        break;
+      case 'validation':
+      default:
+        setErrorMsg('Please fill in every required field, including a handle or contact.');
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="rounded-md border border-green-300 bg-green-50 p-4 text-green-900">
+        <p className="font-medium">Thanks — your talk is under review.</p>
+        <p className="text-sm">You&apos;ll see it on the voting page once organizers approve it.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <p className="text-sm text-neutral-600">
+        Submitting to <strong>{eventName}</strong>. Window closes{' '}
+        {new Date(submissionClosesAt).toLocaleString()}.
+      </p>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Your name</span>
+        <input
+          name="speakerName"
+          required
+          className="w-full rounded border border-neutral-300 p-2"
+          disabled={disabled}
+        />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Public handle (optional if you fill in contact)</span>
+        <input name="handle" className="w-full rounded border border-neutral-300 p-2" disabled={disabled} />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Contact info (optional if you fill in handle)</span>
+        <input name="contact" className="w-full rounded border border-neutral-300 p-2" disabled={disabled} />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Talk title (≤ 80 chars)</span>
+        <input
+          name="title"
+          required
+          maxLength={80}
+          className="w-full rounded border border-neutral-300 p-2"
+          disabled={disabled}
+        />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Short intro (≤ 500 chars)</span>
+        <textarea
+          name="intro"
+          required
+          maxLength={500}
+          rows={4}
+          className="w-full rounded border border-neutral-300 p-2"
+          disabled={disabled}
+        />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Tag (optional)</span>
+        <input name="tag" className="w-full rounded border border-neutral-300 p-2" disabled={disabled} />
+      </label>
+      <label className="flex items-start gap-2 text-sm">
+        <input type="checkbox" name="consent" required disabled={disabled} />
+        <span>
+          I understand this is a 5-minute lightning talk and agree my submission can be displayed publicly for
+          voting.
+        </span>
+      </label>
+      {status === 'error' && (
+        <p role="alert" className="text-sm text-red-700">
+          {errorMsg}
+        </p>
+      )}
+      <button
+        type="submit"
+        disabled={disabled || status === 'submitting'}
+        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+      >
+        {status === 'submitting' ? 'Submitting…' : 'Submit talk'}
+      </button>
+      {disabled && <p className="text-sm text-neutral-600">Submissions are closed.</p>}
+    </form>
+  );
+}
+```
+
+- [ ] **Step 2: Create the server page**
+
+Create `src/app/submit/page.tsx`:
+```tsx
+import { getEventConfig, isWithinWindow } from '@/lib/voting';
+import { SubmissionForm } from './SubmissionForm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SubmitPage() {
+  const event = await getEventConfig();
+  const open = isWithinWindow(event.submissionOpensAt, event.submissionClosesAt, new Date());
+  return (
+    <div className="mx-auto max-w-lg px-4 py-10">
+      <h1 className="mb-2 text-2xl font-semibold">Submit a 5-minute talk</h1>
+      <p className="mb-6 text-sm text-neutral-600">
+        Share something useful, fun, or inspiring with the community.
+      </p>
+      <SubmissionForm
+        disabled={!open}
+        submissionClosesAt={event.submissionClosesAt}
+        eventName={event.name}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/submit/page.tsx src/app/submit/SubmissionForm.tsx
+git commit -m "feat(voting): /submit page + form"
+```
+
+---
+
+## Phase 5 — Admin auth
+
+### Task 5.1: `/api/admin/session` + `/api/admin/logout`
+
+**Files:**
+- Create: `src/app/api/admin/session/route.ts`
+- Create: `src/app/api/admin/logout/route.ts`
+
+- [ ] **Step 1: Create login route**
+
+Create `src/app/api/admin/session/route.ts`:
+```ts
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import {
+  ADMIN_SESSION_COOKIE,
+  constantTimeTokenMatch,
+  newSessionCookieValue,
+} from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({ token: z.string().min(1) });
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+  if (!constantTimeTokenMatch(parsed.data.token)) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+  const { value, expiresAt } = newSessionCookieValue();
+  cookies().set({
+    name: ADMIN_SESSION_COOKIE,
+    value,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    expires: expiresAt,
+  });
+  return new NextResponse(null, { status: 204 });
+}
+```
+
+- [ ] **Step 2: Create logout route**
+
+Create `src/app/api/admin/logout/route.ts`:
+```ts
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { ADMIN_SESSION_COOKIE } from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  cookies().delete(ADMIN_SESSION_COOKIE);
+  return new NextResponse(null, { status: 204 });
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/admin/session/route.ts src/app/api/admin/logout/route.ts
+git commit -m "feat(voting): admin session login + logout"
+```
+
+---
+
+### Task 5.2: `/admin` landing page
+
+**Files:**
+- Create: `src/app/admin/AdminLoginForm.tsx`
+- Create: `src/app/admin/page.tsx`
+
+- [ ] **Step 1: Create client form**
+
+Create `src/app/admin/AdminLoginForm.tsx`:
+```tsx
+'use client';
+
+import { useState } from 'react';
+
+export function AdminLoginForm() {
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'error'>('idle');
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus('submitting');
+    const fd = new FormData(e.currentTarget);
+    const token = String(fd.get('token') ?? '');
+    const res = await fetch('/api/admin/session', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    if (res.status === 204) {
+      window.location.href = '/admin/submissions';
+      return;
+    }
+    setStatus('error');
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Admin token</span>
+        <input
+          name="token"
+          type="password"
+          required
+          className="w-full rounded border border-neutral-300 p-2"
+          autoComplete="off"
+        />
+      </label>
+      {status === 'error' && (
+        <p role="alert" className="text-sm text-red-700">
+          Invalid token.
+        </p>
+      )}
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+      >
+        {status === 'submitting' ? 'Signing in…' : 'Sign in'}
+      </button>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 2: Create landing page**
+
+Create `src/app/admin/page.tsx`:
+```tsx
+import Link from 'next/link';
+import { cookies } from 'next/headers';
+import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import { AdminLoginForm } from './AdminLoginForm';
+
+export const dynamic = 'force-dynamic';
+
+export default function AdminPage() {
+  const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+  const authed = verifySession(session, Date.now());
+
+  if (!authed) {
+    return (
+      <div className="mx-auto max-w-sm px-4 py-10">
+        <h1 className="mb-4 text-2xl font-semibold">Admin sign-in</h1>
+        <AdminLoginForm />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-10">
+      <h1 className="mb-4 text-2xl font-semibold">Admin</h1>
+      <ul className="space-y-2">
+        <li>
+          <Link className="text-blue-700 underline" href="/admin/submissions">
+            Submissions queue
+          </Link>
+        </li>
+        <li>
+          <Link className="text-blue-700 underline" href="/admin/results">
+            Results
+          </Link>
+        </li>
+      </ul>
+      <form action="/api/admin/logout" method="post" className="mt-6">
+        <button type="submit" className="text-sm text-neutral-600 underline">
+          Sign out
+        </button>
+      </form>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/page.tsx src/app/admin/AdminLoginForm.tsx
+git commit -m "feat(voting): /admin landing page"
+```
+
+---
+
+## Phase 6 — Admin moderation
+
+### Task 6.1: `GET|PATCH /api/admin/submissions`
+
+**Files:**
+- Create: `src/app/api/admin/submissions/route.ts`
+
+- [ ] **Step 1: Create route**
+
+Create `src/app/api/admin/submissions/route.ts`:
+```ts
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import {
+  getEventConfig,
+  listSubmissions,
+  setSubmissionStatus,
+  getSubmission,
+} from '@/lib/voting';
+import type { SubmissionStatus } from '@/types/voting';
+
+export const dynamic = 'force-dynamic';
+
+function unauthorized() {
+  return NextResponse.json({ ok: false }, { status: 401 });
+}
+
+function requireSession(): boolean {
+  const v = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+  return verifySession(v, Date.now());
+}
+
+export async function GET(req: Request) {
+  if (!requireSession()) return unauthorized();
+  const url = new URL(req.url);
+  const filter = (url.searchParams.get('status') ?? 'all') as SubmissionStatus | 'all';
+  const event = await getEventConfig();
+  const all = await listSubmissions(event.slug);
+  const submissions = filter === 'all' ? all : all.filter((s) => s.status === filter);
+  return NextResponse.json({ submissions });
+}
+
+const patchSchema = z.object({ status: z.enum(['pending', 'approved', 'rejected']) });
+
+export async function PATCH(req: Request) {
+  if (!requireSession()) return unauthorized();
+  const url = new URL(req.url);
+  const id = url.searchParams.get('id');
+  if (!id) return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  const existing = await getSubmission(id);
+  if (!existing) return NextResponse.json({ ok: false, error: 'not-found' }, { status: 404 });
+  const json = await req.json().catch(() => null);
+  const parsed = patchSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  }
+  await setSubmissionStatus(id, parsed.data.status);
+  return NextResponse.json({ ok: true });
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/admin/submissions/route.ts
+git commit -m "feat(voting): admin submissions GET + PATCH"
+```
+
+---
+
+### Task 6.2: `/admin/submissions` page
+
+**Files:**
+- Create: `src/app/admin/submissions/SubmissionActions.tsx`
+- Create: `src/app/admin/submissions/page.tsx`
+
+- [ ] **Step 1: Create client action buttons**
+
+Create `src/app/admin/submissions/SubmissionActions.tsx`:
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+type Status = 'pending' | 'approved' | 'rejected';
+
+export function SubmissionActions({ id, current }: { id: string; current: Status }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function set(status: Status) {
+    setBusy(true);
+    const res = await fetch(`/api/admin/submissions?id=${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    setBusy(false);
+    if (res.ok) router.refresh();
+    else alert('Update failed.');
+  }
+
+  return (
+    <div className="flex gap-2">
+      <button
+        type="button"
+        disabled={busy || current === 'approved'}
+        onClick={() => set('approved')}
+        className="rounded bg-green-700 px-2 py-1 text-xs text-white disabled:opacity-50"
+      >
+        Approve
+      </button>
+      <button
+        type="button"
+        disabled={busy || current === 'rejected'}
+        onClick={() => set('rejected')}
+        className="rounded bg-red-700 px-2 py-1 text-xs text-white disabled:opacity-50"
+      >
+        Reject
+      </button>
+      <button
+        type="button"
+        disabled={busy || current === 'pending'}
+        onClick={() => set('pending')}
+        className="rounded bg-neutral-700 px-2 py-1 text-xs text-white disabled:opacity-50"
+      >
+        Reset
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create page**
+
+Create `src/app/admin/submissions/page.tsx`:
+```tsx
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import { getEventConfig, listSubmissions, voterCount, listBallots } from '@/lib/voting';
+import type { Submission, SubmissionStatus } from '@/types/voting';
+import { SubmissionActions } from './SubmissionActions';
+
+export const dynamic = 'force-dynamic';
+
+const ORDER: SubmissionStatus[] = ['pending', 'approved', 'rejected'];
+
+function groupByStatus(list: Submission[]): Record<SubmissionStatus, Submission[]> {
+  const out: Record<SubmissionStatus, Submission[]> = { pending: [], approved: [], rejected: [] };
+  for (const s of list) out[s.status].push(s);
+  return out;
+}
+
+export default async function AdminSubmissionsPage() {
+  const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+  if (!verifySession(session, Date.now())) redirect('/admin');
+
+  const event = await getEventConfig();
+  const [all, totalVoters, ballots] = await Promise.all([
+    listSubmissions(event.slug),
+    voterCount(event.slug),
+    listBallots(event.slug),
+  ]);
+  const totalVotes = ballots.reduce((n, b) => n + b.submissionIds.length, 0);
+  const grouped = groupByStatus(all);
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <h1 className="mb-2 text-2xl font-semibold">Submissions</h1>
+      <p className="mb-6 text-sm text-neutral-600">
+        {event.name} · submissions close {new Date(event.submissionClosesAt).toLocaleString()} · voting closes{' '}
+        {new Date(event.votingClosesAt).toLocaleString()} · vote limit {event.voteLimit} · voters {totalVoters} ·
+        total votes {totalVotes}
+      </p>
+      {ORDER.map((status) => (
+        <section key={status} className="mb-8">
+          <h2 className="mb-2 text-lg font-semibold capitalize">
+            {status} ({grouped[status].length})
+          </h2>
+          {grouped[status].length === 0 ? (
+            <p className="text-sm text-neutral-600">None.</p>
+          ) : (
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="py-2 pr-4">Title</th>
+                  <th className="py-2 pr-4">Speaker</th>
+                  <th className="py-2 pr-4">Contact</th>
+                  <th className="py-2 pr-4">Intro</th>
+                  <th className="py-2 pr-4">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {grouped[status].map((s) => (
+                  <tr key={s.id} className="border-b align-top">
+                    <td className="py-2 pr-4 font-medium">{s.title}</td>
+                    <td className="py-2 pr-4">
+                      {s.speakerName}
+                      {s.handle ? ` · ${s.handle}` : ''}
+                    </td>
+                    <td className="py-2 pr-4 text-neutral-700">{s.contact ?? ''}</td>
+                    <td className="py-2 pr-4 text-neutral-700">{s.intro}</td>
+                    <td className="py-2 pr-4">
+                      <SubmissionActions id={s.id} current={s.status} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/submissions/page.tsx src/app/admin/submissions/SubmissionActions.tsx
+git commit -m "feat(voting): admin moderation queue"
+```
+
+---
+
+## Phase 7 — Voting
+
+### Task 7.1: `POST /api/votes`
+
+**Files:**
+- Create: `src/app/api/votes/route.ts`
+
+- [ ] **Step 1: Create route**
+
+Create `src/app/api/votes/route.ts`:
+```ts
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import { VOTER_COOKIE } from '@/middleware';
+import {
+  getBallot,
+  getEventConfig,
+  isWithinWindow,
+  listSubmissions,
+  sameCanonicalBallot,
+  validateBallot,
+  writeBallot,
+} from '@/lib/voting';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({ submissionIds: z.array(z.string().min(1)) });
+
+export async function POST(req: Request) {
+  const voter = cookies().get(VOTER_COOKIE)?.value;
+  if (!voter) {
+    return NextResponse.json({ ok: false, error: 'cookies-required' }, { status: 400 });
+  }
+
+  const event = await getEventConfig();
+  if (!isWithinWindow(event.votingOpensAt, event.votingClosesAt, new Date())) {
+    return NextResponse.json({ ok: false, error: 'closed' }, { status: 400 });
+  }
+
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  }
+  const requested = parsed.data.submissionIds;
+
+  // Initial validation pass
+  const initial = await listSubmissions(event.slug);
+  const approvedIds = new Set(initial.filter((s) => s.status === 'approved').map((s) => s.id));
+  const first = validateBallot(requested, event.voteLimit, approvedIds);
+  if (!first.ok) {
+    return NextResponse.json({ ok: false, error: first.error }, { status: 400 });
+  }
+
+  // Idempotency / already-voted check
+  const existing = await getBallot(event.slug, voter);
+  if (existing) {
+    if (sameCanonicalBallot(existing.submissionIds, requested)) {
+      return NextResponse.json({ ok: true, recorded: existing.submissionIds.length, alreadyRecorded: true });
+    }
+    return NextResponse.json({ ok: false, error: 'already-voted' }, { status: 409 });
+  }
+
+  // Re-read right before writing — talks may have changed status
+  const fresh = await listSubmissions(event.slug);
+  const freshApproved = new Set(fresh.filter((s) => s.status === 'approved').map((s) => s.id));
+  const final = requested.filter((id) => freshApproved.has(id));
+  if (final.length === 0) {
+    return NextResponse.json({ ok: false, error: 'selection-unavailable' }, { status: 409 });
+  }
+
+  await writeBallot(event.slug, voter, {
+    submissionIds: final,
+    submittedAt: new Date().toISOString(),
+  });
+
+  const dropped = requested.length - final.length;
+  return NextResponse.json({
+    ok: true,
+    recorded: final.length,
+    ...(dropped > 0 ? { dropped } : {}),
+  });
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/votes/route.ts
+git commit -m "feat(voting): POST /api/votes (idempotent, write-once)"
+```
+
+---
+
+### Task 7.2: `/vote` page + `<VoteClient />`
+
+**Files:**
+- Create: `src/app/vote/VoteClient.tsx`
+- Create: `src/app/vote/page.tsx`
+
+- [ ] **Step 1: Create client**
+
+Create `src/app/vote/VoteClient.tsx`:
+```tsx
+'use client';
+
+import { useState } from 'react';
+
+interface Card {
+  id: string;
+  title: string;
+  speakerName: string;
+  handle?: string;
+  tag?: string;
+  intro: string;
+}
+
+export function VoteClient({ cards, voteLimit }: { cards: Card[]; voteLimit: number }) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState<string>('');
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else if (next.size < voteLimit) next.add(id);
+      return next;
+    });
+  }
+
+  async function submit() {
+    setStatus('submitting');
+    const res = await fetch('/api/votes', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ submissionIds: Array.from(selected) }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.ok) {
+      setStatus('success');
+      const dropped = Number(data.dropped ?? 0);
+      setMessage(
+        dropped > 0
+          ? 'Vote recorded, but some selections were no longer available.'
+          : data.alreadyRecorded
+            ? 'You already submitted this ballot. Nothing changed.'
+            : 'Thanks — your vote has been recorded.'
+      );
+      return;
+    }
+    setStatus('error');
+    switch (data.error) {
+      case 'already-voted':
+        setMessage('This browser has already submitted a ballot.');
+        break;
+      case 'selection-unavailable':
+        setMessage('Your selected talks changed while you were voting. Refresh and try again.');
+        break;
+      case 'closed':
+        setMessage('Voting is closed.');
+        break;
+      case 'cookies-required':
+        setMessage('Please enable cookies and reload.');
+        break;
+      case 'unknown-submission':
+        setMessage('One of your selections is no longer available. Refresh and try again.');
+        break;
+      default:
+        setMessage('Could not record your vote. Try again.');
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="rounded-md border border-green-300 bg-green-50 p-4 text-green-900">
+        <p className="font-medium">{message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-neutral-600">
+        Pick up to {voteLimit} talks. {selected.size}/{voteLimit} selected.
+      </p>
+      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {cards.map((c) => {
+          const isSelected = selected.has(c.id);
+          return (
+            <li key={c.id}>
+              <button
+                type="button"
+                onClick={() => toggle(c.id)}
+                className={`w-full rounded-lg border p-4 text-left transition ${
+                  isSelected ? 'border-black bg-neutral-900 text-white' : 'border-neutral-300 bg-white'
+                }`}
+                aria-pressed={isSelected}
+              >
+                <div className="font-medium">{c.title}</div>
+                <div className="text-xs opacity-80">
+                  {c.speakerName}
+                  {c.handle ? ` · ${c.handle}` : ''}
+                  {c.tag ? ` · ${c.tag}` : ''}
+                </div>
+                <p className="mt-2 text-sm opacity-90">{c.intro}</p>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {status === 'error' && (
+        <p role="alert" className="text-sm text-red-700">
+          {message}
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={submit}
+        disabled={selected.size === 0 || status === 'submitting'}
+        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+      >
+        {status === 'submitting' ? 'Submitting…' : `Submit vote (${selected.size})`}
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create page**
+
+Create `src/app/vote/page.tsx`:
+```tsx
+import { cookies } from 'next/headers';
+import { VOTER_COOKIE } from '@/middleware';
+import {
+  getBallot,
+  getEventConfig,
+  isWithinWindow,
+  listSubmissions,
+  shuffleWithSeed,
+} from '@/lib/voting';
+import { VoteClient } from './VoteClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function VotePage() {
+  const event = await getEventConfig();
+  const open = isWithinWindow(event.votingOpensAt, event.votingClosesAt, new Date());
+  const voter = cookies().get(VOTER_COOKIE)?.value;
+  const seed = (voter ?? `anon-${Date.now()}`) + ':' + event.slug;
+  const [all, existing] = await Promise.all([
+    listSubmissions(event.slug),
+    voter ? getBallot(event.slug, voter) : Promise.resolve(null),
+  ]);
+  const approved = all.filter((s) => s.status === 'approved');
+  const cards = shuffleWithSeed(
+    approved.map((s) => ({
+      id: s.id,
+      title: s.title,
+      speakerName: s.speakerName,
+      handle: s.handle,
+      tag: s.tag,
+      intro: s.intro,
+    })),
+    seed
+  );
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10">
+      <h1 className="mb-2 text-2xl font-semibold">Vote for talks you want to hear</h1>
+      <p className="mb-6 text-sm text-neutral-600">
+        {event.name} · voting closes {new Date(event.votingClosesAt).toLocaleString()}
+      </p>
+
+      {existing ? (
+        <div className="rounded-md border border-neutral-300 bg-neutral-50 p-4">
+          <p className="font-medium">You&apos;ve already voted from this browser.</p>
+          <p className="text-sm text-neutral-700">
+            {existing.submissionIds.length} selection(s) recorded at{' '}
+            {new Date(existing.submittedAt).toLocaleString()}.
+          </p>
+        </div>
+      ) : !open ? (
+        <div className="rounded-md border border-neutral-300 bg-neutral-50 p-4">
+          <p className="font-medium">
+            {Date.now() < new Date(event.votingOpensAt).getTime()
+              ? `Voting opens ${new Date(event.votingOpensAt).toLocaleString()}.`
+              : 'Voting is closed. Results will be announced soon.'}
+          </p>
+        </div>
+      ) : approved.length === 0 ? (
+        <p className="text-sm text-neutral-700">No talks are available for voting yet.</p>
+      ) : (
+        <VoteClient cards={cards} voteLimit={event.voteLimit} />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/vote/page.tsx src/app/vote/VoteClient.tsx
+git commit -m "feat(voting): /vote page + selection UI"
+```
+
+---
+
+## Phase 8 — Admin results
+
+### Task 8.1: `GET /api/admin/results`
+
+**Files:**
+- Create: `src/app/api/admin/results/route.ts`
+
+- [ ] **Step 1: Create route**
+
+Create `src/app/api/admin/results/route.ts`:
+```ts
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import {
+  getEventConfig,
+  listBallots,
+  listSubmissions,
+  tallyVotes,
+  voterCount,
+} from '@/lib/voting';
+import type { Submission } from '@/types/voting';
+
+export const dynamic = 'force-dynamic';
+
+function assignRanks(rows: Array<Submission & { voteCount: number }>): Array<Submission & { voteCount: number; rank: number }> {
+  const sorted = [...rows].sort((a, b) => b.voteCount - a.voteCount);
+  let rank = 0;
+  let lastCount = -1;
+  let seen = 0;
+  return sorted.map((r) => {
+    seen += 1;
+    if (r.voteCount !== lastCount) {
+      rank = seen;
+      lastCount = r.voteCount;
+    }
+    return { ...r, rank };
+  });
+}
+
+export async function GET() {
+  const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+  if (!verifySession(session, Date.now())) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+
+  const event = await getEventConfig();
+  const [subs, ballots, totalVoters] = await Promise.all([
+    listSubmissions(event.slug),
+    listBallots(event.slug),
+    voterCount(event.slug),
+  ]);
+  const approvedIds = new Set(subs.filter((s) => s.status === 'approved').map((s) => s.id));
+  const counts = tallyVotes(ballots, approvedIds);
+  const totalVotes = ballots.reduce((n, b) => n + b.submissionIds.length, 0);
+
+  const rows = subs.map((s) => ({ ...s, voteCount: counts.get(s.id) ?? 0 }));
+  const ranked = assignRanks(rows).map((r) => ({
+    id: r.id,
+    title: r.title,
+    speakerName: r.speakerName,
+    handle: r.handle,
+    contact: r.contact,
+    tag: r.tag,
+    status: r.status,
+    voteCount: r.voteCount,
+    rank: r.rank,
+  }));
+
+  return NextResponse.json({ totalVoters, totalVotes, results: ranked });
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/admin/results/route.ts
+git commit -m "feat(voting): admin results endpoint"
+```
+
+---
+
+### Task 8.2: `/admin/results` page
+
+**Files:**
+- Create: `src/app/admin/results/ResultsExport.tsx`
+- Create: `src/app/admin/results/page.tsx`
+
+- [ ] **Step 1: Create CSV export client**
+
+Create `src/app/admin/results/ResultsExport.tsx`:
+```tsx
+'use client';
+
+interface Row {
+  rank: number;
+  title: string;
+  speakerName: string;
+  handle?: string;
+  contact?: string;
+  tag?: string;
+  status: string;
+  voteCount: number;
+}
+
+function csvEscape(v: string): string {
+  if (/[",\n]/.test(v)) return `"${v.replace(/"/g, '""')}"`;
+  return v;
+}
+
+export function ResultsExport({ rows, filename }: { rows: Row[]; filename: string }) {
+  function download() {
+    const header = ['rank', 'title', 'speaker', 'handle', 'contact', 'tag', 'status', 'voteCount'];
+    const lines = [header.join(',')];
+    for (const r of rows) {
+      lines.push(
+        [
+          String(r.rank),
+          csvEscape(r.title),
+          csvEscape(r.speakerName),
+          csvEscape(r.handle ?? ''),
+          csvEscape(r.contact ?? ''),
+          csvEscape(r.tag ?? ''),
+          r.status,
+          String(r.voteCount),
+        ].join(',')
+      );
+    }
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <button type="button" onClick={download} className="rounded bg-black px-3 py-1 text-sm text-white">
+      Download CSV
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: Create page**
+
+Create `src/app/admin/results/page.tsx`:
+```tsx
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import {
+  getEventConfig,
+  isWithinWindow,
+  listBallots,
+  listSubmissions,
+  tallyVotes,
+  voterCount,
+} from '@/lib/voting';
+import type { Submission } from '@/types/voting';
+import { ResultsExport } from './ResultsExport';
+
+export const dynamic = 'force-dynamic';
+
+function assignRanks(rows: Array<Submission & { voteCount: number }>) {
+  const sorted = [...rows].sort((a, b) => b.voteCount - a.voteCount);
+  let rank = 0;
+  let lastCount = -1;
+  let seen = 0;
+  return sorted.map((r) => {
+    seen += 1;
+    if (r.voteCount !== lastCount) {
+      rank = seen;
+      lastCount = r.voteCount;
+    }
+    return { ...r, rank };
+  });
+}
+
+export default async function AdminResultsPage() {
+  const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+  if (!verifySession(session, Date.now())) redirect('/admin');
+
+  const event = await getEventConfig();
+  const [subs, ballots, totalVoters] = await Promise.all([
+    listSubmissions(event.slug),
+    listBallots(event.slug),
+    voterCount(event.slug),
+  ]);
+  const approvedIds = new Set(subs.filter((s) => s.status === 'approved').map((s) => s.id));
+  const counts = tallyVotes(ballots, approvedIds);
+  const totalVotes = ballots.reduce((n, b) => n + b.submissionIds.length, 0);
+  const rows = assignRanks(subs.map((s) => ({ ...s, voteCount: counts.get(s.id) ?? 0 })));
+  const votingOpen = isWithinWindow(event.votingOpensAt, event.votingClosesAt, new Date());
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <div className="mb-4 flex items-baseline justify-between gap-4">
+        <h1 className="text-2xl font-semibold">Results</h1>
+        <ResultsExport
+          rows={rows.map((r) => ({
+            rank: r.rank,
+            title: r.title,
+            speakerName: r.speakerName,
+            handle: r.handle,
+            contact: r.contact,
+            tag: r.tag,
+            status: r.status,
+            voteCount: r.voteCount,
+          }))}
+          filename={`${event.slug}-results.csv`}
+        />
+      </div>
+      <p className="mb-6 text-sm text-neutral-600">
+        {event.name} ·{' '}
+        {votingOpen
+          ? `voting closes ${new Date(event.votingClosesAt).toLocaleString()}`
+          : 'Final ranking'}{' '}
+        · voters {totalVoters} · total votes {totalVotes}
+      </p>
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="py-2 pr-4">Rank</th>
+            <th className="py-2 pr-4">Title</th>
+            <th className="py-2 pr-4">Speaker</th>
+            <th className="py-2 pr-4">Contact</th>
+            <th className="py-2 pr-4">Tag</th>
+            <th className="py-2 pr-4">Status</th>
+            <th className="py-2 pr-4">Votes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id} className="border-b align-top">
+              <td className="py-2 pr-4">{r.rank}</td>
+              <td className="py-2 pr-4 font-medium">{r.title}</td>
+              <td className="py-2 pr-4">
+                {r.speakerName}
+                {r.handle ? ` · ${r.handle}` : ''}
+              </td>
+              <td className="py-2 pr-4 text-neutral-700">{r.contact ?? ''}</td>
+              <td className="py-2 pr-4">{r.tag ?? ''}</td>
+              <td className="py-2 pr-4">{r.status}</td>
+              <td className="py-2 pr-4">{r.voteCount}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/results/page.tsx src/app/admin/results/ResultsExport.tsx
+git commit -m "feat(voting): admin results page + CSV export"
+```
+
+---
+
+## Phase 9 — E2E smoke test + finalize
+
+### Task 9.1: Playwright smoke spec
+
+**Files:**
+- Create: `e2e/lightning-talk-voting.spec.ts`
+
+**Note:** This spec requires a working KV connection so that submissions / votes persist between HTTP calls. If running locally, `vercel env pull .env.local` before `npm run test:e2e`. If KV is not reachable, skip this task and rely on the unit tests plus a manual walkthrough.
+
+- [ ] **Step 1: Create the spec**
+
+Create `e2e/lightning-talk-voting.spec.ts`:
+```ts
+import { test, expect, request } from '@playwright/test';
+
+const ADMIN_TOKEN = process.env.E2E_ADMIN_TOKEN ?? 'change-me-matching-ADMIN_TOKEN';
+
+test('speaker submits, admin approves, voter votes once, already-voted on retry', async ({
+  page,
+  baseURL,
+}) => {
+  // Speaker: open /submit and submit a talk
+  await page.goto('/submit');
+  await page.fill('input[name="speakerName"]', 'E2E Speaker');
+  await page.fill('input[name="handle"]', '@e2e');
+  await page.fill('input[name="title"]', 'E2E Lightning Talk');
+  await page.fill('textarea[name="intro"]', 'A short test intro for the end-to-end smoke.');
+  await page.check('input[name="consent"]');
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/submissions') && r.request().method() === 'POST'),
+    page.click('button[type="submit"]'),
+  ]);
+  await expect(page.getByText('Thanks — your talk is under review.')).toBeVisible();
+
+  // Admin: log in, find pending submission, approve it
+  const ctx = await request.newContext({ baseURL });
+  const login = await ctx.post('/api/admin/session', { data: { token: ADMIN_TOKEN } });
+  expect(login.status()).toBe(204);
+
+  const list = await ctx.get('/api/admin/submissions?status=pending');
+  expect(list.ok()).toBe(true);
+  const pendingBody = await list.json();
+  const target = pendingBody.submissions.find((s: { title: string; id: string }) =>
+    s.title === 'E2E Lightning Talk'
+  );
+  expect(target).toBeTruthy();
+  const patch = await ctx.patch(`/api/admin/submissions?id=${target.id}`, {
+    data: { status: 'approved' },
+  });
+  expect(patch.ok()).toBe(true);
+
+  // Voter: open /vote and cast a ballot for the approved talk
+  await page.goto('/vote');
+  await page.getByRole('button', { name: /E2E Lightning Talk/ }).click();
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/votes') && r.request().method() === 'POST'),
+    page.getByRole('button', { name: /Submit vote/ }).click(),
+  ]);
+  await expect(page.getByText(/your vote has been recorded/i)).toBeVisible();
+
+  // Reload /vote -- should now show "already voted" state
+  await page.goto('/vote');
+  await expect(page.getByText(/already voted from this browser/i)).toBeVisible();
+
+  // Admin: results should include the approved talk with voteCount >= 1
+  const results = await ctx.get('/api/admin/results');
+  expect(results.ok()).toBe(true);
+  const resultsBody = await results.json();
+  const row = resultsBody.results.find((r: { id: string }) => r.id === target.id);
+  expect(row).toBeTruthy();
+  expect(row.voteCount).toBeGreaterThanOrEqual(1);
+});
+```
+
+- [ ] **Step 2: Run the spec locally**
+
+Before running, ensure `.env.local` has `ADMIN_TOKEN=<value>` and KV envs pulled from Vercel, then run:
+```bash
+E2E_ADMIN_TOKEN="$ADMIN_TOKEN" npm run test:e2e -- lightning-talk-voting.spec.ts
+```
+
+Expected: the spec passes end-to-end.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/lightning-talk-voting.spec.ts
+git commit -m "test(voting): playwright smoke spec"
+```
+
+---
+
+### Task 9.2: README + operational docs, placeholders, and full check suite
+
+**Files:**
+- Modify: `README.md`
+- Create: `public/events/.gitkeep`
+
+- [ ] **Step 1: Append a short section to `README.md`**
+
+Append this section (adjust the heading level to match the existing README) to `README.md`:
+```md
+## Lightning Talk Voting
+
+Single-event submission + voting tool under `/submit`, `/vote`, and `/admin`.
+
+**Required env vars** (see `.env.example`):
+
+- `KV_REST_API_URL`, `KV_REST_API_TOKEN` — Vercel KV (run `vercel env pull .env.local` after linking the KV store)
+- `ADMIN_TOKEN` — used for admin login and session-cookie signing; generate 32+ random bytes
+
+**Event config:** edit `content/events/lightning-talk.json` and redeploy. Runtime edits are not supported.
+
+**QR codes:** generate PNGs from the production URLs (`/submit` and `/vote`) using any external QR generator, then drop them into `public/events/` as `lightning-talk-qr-submit.png` and `lightning-talk-qr-vote.png`. Regenerate if the production domain changes.
+
+**After the event:** keep `content/events/lightning-talk.json` as an archive; purge KV data with a one-off script if desired.
+```
+
+- [ ] **Step 2: Create `.gitkeep` for the QR directory**
+
+Create `public/events/.gitkeep` with empty content.
+
+- [ ] **Step 3: Run the full check suite**
+
+Run:
+```bash
+npm run lint && npx tsc --noEmit && npx vitest run && npm run build
+```
+
+Expected: all pass. If any step fails, fix before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md public/events/.gitkeep
+git commit -m "docs(voting): README section + QR directory placeholder"
+```
+
+- [ ] **Step 5: Final verification**
+
+Manual spot-check (~10 min, using local `.env.local` with KV + `ADMIN_TOKEN`):
+
+1. `npm run dev`
+2. Visit `/submit` on phone → submit a talk → confirm confirmation state.
+3. Visit `/admin` → sign in → approve the talk in `/admin/submissions`.
+4. Open `/vote` in a new incognito window → vote → confirm "recorded".
+5. Reload `/vote` → confirm "already voted" state.
+6. Visit `/admin/results` → confirm ranking + CSV download.
+
+---
+
+## Self-review checklist
+
+Run this after completing the plan — not a subagent dispatch.
+
+**1. Spec coverage** — map every spec section to tasks:
+
+| Spec section | Tasks |
+|---|---|
+| §3 Architecture / file layout | 0.2, 1.1, 1.2, 2.1, 3.1, 4.x, 5.x, 6.x, 7.x, 8.x |
+| §4.1 Event config | 0.2 |
+| §4.2 KV keys (submissions, ballots, voters, rate-limit) | 2.1 |
+| §5.1 `/submit` public page + validation rules | 4.2, 4.1 |
+| §5.1 `/vote` public page + shuffle + already-voted state | 7.2, 1.1 |
+| §5.2 `/admin` session-based gate | 5.2, 1.2 |
+| §5.2 `/admin/submissions` queue | 6.2 |
+| §5.2 `/admin/results` ranking + CSV | 8.2 |
+| §5.3 QR codes | 9.2 (docs), `public/events/` placeholder |
+| §6.1 POST /api/submissions contract | 4.1 |
+| §6.2 POST /api/votes contract (idempotent, write-once, partial-drop, already-voted, selection-unavailable) | 7.1, 1.1 |
+| §6.3 POST /api/admin/session | 5.1 |
+| §6.4 POST /api/admin/logout | 5.1 |
+| §6.5 GET/PATCH /api/admin/submissions | 6.1 |
+| §6.6 GET /api/admin/results (ranking + tallyVotes filter) | 8.1, 1.1 |
+| §7 Error handling / user copy | 4.2, 7.2 |
+| §7 Race handling (re-read before write, tally filters) | 7.1, 1.1, 8.1 |
+| §8 Unit tests (isWithinWindow, validation, canonical, tally) | 1.1 |
+| §8 Unit tests (token compare, session sign/verify) | 1.2 |
+| §8 Playwright smoke | 9.1 |
+| §9 Env vars | 0.1, 9.2 |
+| §10 Operational notes | 9.2 |
+
+No gaps.
+
+**2. Placeholder scan** — no `TBD`, no `TODO`, no "implement appropriate error handling" style hand-waves. Every step that writes code shows the code. Every step with a command shows the command.
+
+**3. Type consistency** — exported names used across tasks:
+- `VOTER_COOKIE` defined in Task 3.1 (`src/middleware.ts`), imported in 4.1, 7.1, 7.2 ✓
+- `ADMIN_SESSION_COOKIE` defined in Task 1.2, imported in 5.1, 5.2, 6.1, 6.2, 8.1, 8.2 ✓
+- `verifySession(value, nowMs)` signature matches across all call sites ✓
+- `Submission`, `Ballot`, `SubmissionStatus` types defined in Task 0.2, used uniformly ✓
+- `isWithinWindow(opens, closes, now)` signature stable across calls ✓
+- `tallyVotes(ballots, approvedIds)` called with `Ballot[]` and `Set<string>` in 8.1 and 8.2 ✓
+- `shuffleWithSeed(items, seed)` deterministic in 7.2 — seed built from voter cookie + event slug, matches spec §5.1 ✓

--- a/docs/superpowers/specs/2026-04-19-lightning-talk-voting-design.md
+++ b/docs/superpowers/specs/2026-04-19-lightning-talk-voting-design.md
@@ -1,0 +1,250 @@
+# Design — Community Lightning Talk Voting
+
+**Status:** Draft — pending user review
+**Date:** 2026-04-19
+**Source PRD:** `docs/community-lightning-talk-voting-prd.md`
+
+## 1. Goal
+
+Ship a mobile-first, QR-driven lightning-talk submission and voting tool on top of the existing 02ship.com Next.js app, with no database and no auth framework. Stores data in Vercel KV. Scoped to a single hardcoded event.
+
+## 2. Non-goals (explicit cuts from the PRD)
+
+- Multi-event support
+- Full admin dashboard UI with filters and bulk actions (replaced by a minimal token-gated table)
+- Account system or OAuth (Discord, wallet, magic link)
+- Voter search/filter on the voting page
+- Voter vote editing
+- Speaker submission editing
+- Comment system, speaker profiles, gamification, leaderboards
+- Runtime QR code generation
+- Live public vote counts
+
+## 3. Architecture
+
+A single-event, mobile-first voting feature bolted onto the existing Next.js 14 / Vercel app. Write store is **Vercel KV**; event metadata is a JSON file committed to the repo.
+
+```
+content/events/lightning-talk.json       # event config
+src/app/submit/page.tsx                  # QR 1 target
+src/app/vote/page.tsx                    # QR 2 target
+src/app/admin/page.tsx                   # landing (token prompt)
+src/app/admin/submissions/page.tsx       # moderation queue
+src/app/admin/results/page.tsx           # ranked tally
+src/app/api/submissions/route.ts         # POST new submission
+src/app/api/votes/route.ts               # POST ballot
+src/app/api/admin/submissions/route.ts   # GET/PATCH (token)
+src/app/api/admin/results/route.ts       # GET (token)
+src/lib/voting.ts                        # KV + cookie helpers, tallyVotes
+src/lib/admin.ts                         # timing-safe token check
+src/middleware.ts                        # sets zts_voter cookie if missing
+public/events/lightning-talk-qr-submit.png
+public/events/lightning-talk-qr-vote.png
+```
+
+**End-to-end flow:**
+1. Organizer edits `content/events/lightning-talk.json` and deploys.
+2. Speaker scans QR 1 → `/submit` → POST `/api/submissions` → KV `submission:<id>` with `status: pending`.
+3. Organizer visits `/admin/submissions?token=...` → PATCH `/api/admin/submissions?id=<id>` → status → `approved`.
+4. Voter scans QR 2 → `/vote` → sees approved submissions in per-session-randomized order, no counts → selects up to `voteLimit` → POST `/api/votes` → KV `vote:<event>:<voterUuid>` = ballot.
+5. Organizer watches `/admin/results?token=...`. After `votingClosesAt`, publishes final list.
+
+**Design choices (locked in during brainstorming):**
+- Vercel KV is the only write store.
+- Event config committed to the repo (git-versioned). Redeploy to change.
+- Anonymous voter identity via `httpOnly`, `SameSite=Lax` UUID cookie `zts_voter`, set by Next.js middleware on first request to any `/submit`, `/vote`, or `/api/{submissions,votes}` path. This guarantees the cookie exists before any page renders or any API handler runs, avoiding a race between the cookie-seeded shuffle and a cookieless first visit.
+- Organizer-only vote-count visibility to avoid popularity bias; voter sees cards in a per-session-randomized order seeded from the cookie.
+- Admin endpoints gated by `ADMIN_TOKEN` env var compared with `crypto.timingSafeEqual`.
+- Submission anti-spam: same cookie keys a 24h rate-limit counter, cap 3 submissions per browser.
+
+## 4. Data model
+
+### 4.1 Event config (repo file)
+
+`content/events/lightning-talk.json`:
+
+```json
+{
+  "slug": "lightning-talk",
+  "name": "Community Lightning Talks — April 2026",
+  "submissionOpensAt": "2026-04-15T00:00:00Z",
+  "submissionClosesAt": "2026-04-25T23:59:00Z",
+  "votingOpensAt": "2026-04-20T00:00:00Z",
+  "votingClosesAt": "2026-04-27T23:59:00Z",
+  "voteLimit": 3,
+  "submissionLimitPerCookie": 3
+}
+```
+
+Typed by a new `src/types/event.ts`. Loaded via `getEventConfig()` in `src/lib/voting.ts`.
+
+### 4.2 Vercel KV keys
+
+| Key | Value shape | Purpose |
+|---|---|---|
+| `submission:<uuid>` | `{ id, event, speakerName, handle?, contact?, title, intro, tag?, status, createdAt }` | One submission. `status ∈ "pending" \| "approved" \| "rejected"`. |
+| `submissions:index:<event>` | `string[]` of submission IDs | Cheap iteration; append-only. |
+| `vote:<event>:<voterUuid>` | `string[]` of submission IDs, length ≤ `voteLimit` | Full ballot per voter. Overwrite is allowed (idempotent). |
+| `voters:index:<event>` | `string[]` of voter UUIDs | For `totalVoters` in results. |
+| `submit-rate:<cookieUuid>` | `number`, TTL 86400s | Submission counter per browser, 24h window. |
+
+**Rationale:**
+- Per-submission keys make status updates atomic single `SET`s.
+- Index keys work around KV's lack of `SCAN`.
+- Per-voter ballot key: one write per voter, idempotent overwrite, trivial future "edit before close".
+- No aggregated counters stored — `tallyVotes()` always computes — so counts can't drift.
+
+## 5. Routes and pages
+
+### 5.1 Public pages
+
+- **`/submit`** — Server reads event config, renders `<SubmissionForm />` client component. Fields: `speakerName` (required), `handle` (optional), `contact` (optional), `title` (≤ 80 chars, required), `intro` (≤ 500 chars, required), `tag` (optional), `consent` (required checkbox). Top copy: "Submit a 5-minute talk idea" + event name + close time. Banner "Submissions are closed" when `now` is outside the submission window. On success, page state switches to "Thanks, your submission is under review."
+- **`/vote`** — Server fetches approved submissions from KV, shuffles with a seed stored in the voter cookie (so refresh keeps the same order for that voter), renders `<VoteClient />`. Voter taps up to `voteLimit` cards to toggle selection. "Submit vote" button POSTs ballot. After success, page state switches to confirmation with share CTAs. Banner "Voting is closed" outside window. No vote counts visible anywhere.
+
+### 5.2 Admin pages (token-gated)
+
+All admin pages are server components that read `?token=` from the URL and compare it with `ADMIN_TOKEN` via `crypto.timingSafeEqual`. If missing or wrong, the page renders a "paste your token" form that GETs back to the same path with `?token=<input>`. Token stays in the URL on every navigation (admin bookmarks include it). Server components pass `token` as a prop to any client component that needs to issue mutations; those components include it in the `x-admin-token` header on `fetch`. No `sessionStorage`, no cookie, no client-side persistence of the token.
+
+- **`/admin`** — Landing. On valid token, renders links to `/admin/submissions?token=...` and `/admin/results?token=...`.
+- **`/admin/submissions`** — Moderation queue. Table grouped by status (pending first). Each row: title, speaker, intro preview, tag, Approve / Reject / Reset-to-pending buttons. Buttons live in a client component that receives `token` as a prop and PATCHes `/api/admin/submissions?id=<id>` with `x-admin-token`. Header shows total submissions per status plus `totalVoters` and `totalVotes` snapshot (fetched server-side).
+- **`/admin/results`** — Ranked results table: rank (ties share), title, speaker, vote count, tag, status. "Voting closes in Xh" while open; "Final results" after close. "Download CSV" button generates a CSV client-side from data already on the page.
+
+### 5.3 QR codes
+
+Not a page. Generated once via any external QR generator from the full absolute URLs:
+
+- `https://02ship.com/submit`
+- `https://02ship.com/vote`
+
+Saved as PNGs in `public/events/` and linked from a private Notion/doc. No runtime generation.
+
+## 6. API endpoints
+
+All under `src/app/api/`. JSON in, JSON out. Most logic lives in `src/lib/voting.ts`; routes are thin.
+
+### 6.1 `POST /api/submissions`
+
+**Request body**
+```ts
+{ speakerName: string; handle?: string; contact?: string;
+  title: string; intro: string; tag?: string; consent: boolean }
+```
+
+**Validations (server-side, all enforced):**
+- `event.submissionOpensAt <= now < event.submissionClosesAt`
+- `title.length` in `[1, 80]`
+- `intro.length` in `[1, 500]`
+- `consent === true`
+- `submit-rate:<cookieUuid>` < `event.submissionLimitPerCookie`
+
+**Side effects (ordered):**
+1. Read `zts_voter` cookie (guaranteed set by middleware).
+2. `id = crypto.randomUUID()`.
+3. `SET submission:<id>` with `status: "pending"`, `createdAt: nowIso`.
+4. Append `id` to `submissions:index:<event>`.
+5. `INCR submit-rate:<cookieUuid>` and `EXPIRE 86400` on first hit.
+
+**Responses**
+- `200 { ok: true, id }`
+- `400 { ok: false, error: "validation" | "closed" | "rate-limited" }`
+
+### 6.2 `POST /api/votes`
+
+**Request body**
+```ts
+{ submissionIds: string[] }  // length 1..voteLimit
+```
+
+**Validations:**
+- `event.votingOpensAt <= now < event.votingClosesAt`
+- `submissionIds.length` in `[1, voteLimit]`
+- No duplicates within the array.
+- Every id exists in KV AND `submission.status === "approved"`. Unknown or non-approved IDs: return `unknown-submission` (we do NOT silently drop in the normal vote path; see §7 for the post-hoc rejection edge case).
+
+**Side effects (ordered):**
+1. Read `zts_voter` cookie (guaranteed set by middleware).
+2. `SET vote:<event>:<voterUuid>` = `submissionIds`.
+3. Add `voterUuid` to `voters:index:<event>` if new.
+
+**Responses**
+- `200 { ok: true, recorded: submissionIds.length }`
+- `400 { ok: false, error: "validation" | "closed" | "unknown-submission" }`
+
+### 6.3 `GET|PATCH /api/admin/submissions`
+
+Auth: header `x-admin-token` compared with `ADMIN_TOKEN` env var using `crypto.timingSafeEqual`.
+
+- `GET /api/admin/submissions?status=pending|approved|rejected|all` → `{ submissions: Submission[] }`
+- `PATCH /api/admin/submissions?id=<uuid>` with body `{ status: "approved" | "rejected" | "pending" }` → `{ ok: true }`
+- `401` on missing/wrong token.
+
+### 6.4 `GET /api/admin/results`
+
+Auth: same.
+
+**Response**
+```ts
+{
+  totalVoters: number,
+  totalVotes: number,
+  results: Array<{
+    id: string, title: string, speakerName: string,
+    handle?: string, tag?: string, status: Status,
+    voteCount: number, rank: number
+  }>
+}
+```
+
+Sorted by `voteCount` desc; ties share rank (1, 1, 3, ...).
+
+## 7. Error handling and edge cases
+
+**User-facing failures** (inline banner, never throw):
+- Submission outside window → "Submissions are closed" with close time.
+- Voting outside window → "Voting is closed. Results will be announced soon."
+- Submission rate-limited → "You've reached the limit of 3 submissions from this browser."
+- Cookies disabled → form POST fails because we can't identify the voter; show "Please enable cookies to vote" with a retry button.
+
+**Post-hoc rejection edge case** (organizer rejects a talk while a voter is choosing):
+- Server-side when saving the ballot: filter `submissionIds` to only those currently `approved`, persist the filtered array.
+- If anything was filtered, respond `200 { ok: true, recorded: N, dropped: M }`; client shows "Vote recorded (N of N+M counted — some selections were no longer available)."
+- This is the ONE case where we silently drop IDs; the normal-path validation in §6.2 still rejects IDs that were never approved.
+
+**Admin failures:**
+- Wrong/missing token → 401; admin pages render the "paste token" form.
+- KV unavailable → error boundary renders "Service temporarily unavailable, please retry." No auto-retry.
+
+**Race conditions we accept without locking:**
+- Two voters submit simultaneously → different keys, no lock needed.
+- Two admin tabs approve the same submission → last write wins.
+- Voter voted, admin later rejects a talk on their ballot → ballot key still contains the rejected ID, but `tallyVotes()` filters by `submission.status === "approved"`, so counts stay correct without rewriting ballots.
+
+**Explicit non-guards:**
+- Abuser clearing cookies to vote twice — accepted cost of cookie-only identity.
+- Replay of a submitted ballot via curl — same voterUuid = same key = idempotent overwrite.
+
+## 8. Testing
+
+Intentionally lightweight for a short-lived, single-event tool.
+
+1. **Unit tests** at `src/lib/__tests__/voting.test.ts` (Vitest, matching existing setup) for pure functions:
+   - `isWithinWindow(opens, closes, now)`
+   - `tallyVotes(ballots, submissions)` — including the "rejected submission on ballot" case
+   - Ballot-shape validator (length, duplicates, unknown IDs)
+2. **Smoke script** at `scripts/smoke-voting.mjs` against a local dev server + scratch KV namespace: submit 3 talks → approve 2 via admin API → cast 2 ballots → fetch results, assert counts and rank order.
+3. **No E2E browser tests.** Two forms and a table; manual QA on a real phone for 10 minutes before the event is cheaper and higher-signal than Playwright here.
+
+## 9. Environment variables
+
+| Var | Purpose | Where |
+|---|---|---|
+| `KV_REST_API_URL` | Vercel KV | Vercel project env (auto-set when KV linked) |
+| `KV_REST_API_TOKEN` | Vercel KV | Vercel project env (auto-set when KV linked) |
+| `ADMIN_TOKEN` | Moderator auth | Set manually in Vercel project env; share out-of-band |
+
+## 10. Open operational notes
+
+- The organizer needs a strong random `ADMIN_TOKEN` (e.g., 32 bytes base64) set before launch.
+- KV must be provisioned and linked to the Vercel project before the first write.
+- QR codes need to be regenerated if the production domain changes.
+- After the event, `content/events/lightning-talk.json` can stay in the repo as an archived record; KV data can be purged with a one-off `scripts/purge-event.mjs` if desired.

--- a/docs/superpowers/specs/2026-04-19-lightning-talk-voting-design.md
+++ b/docs/superpowers/specs/2026-04-19-lightning-talk-voting-design.md
@@ -1,65 +1,74 @@
 # Design — Community Lightning Talk Voting
 
-**Status:** Draft — pending user review
-**Date:** 2026-04-19
+**Status:** Draft — revised after architecture review  
+**Date:** 2026-04-19  
 **Source PRD:** `docs/community-lightning-talk-voting-prd.md`
 
 ## 1. Goal
 
-Ship a mobile-first, QR-driven lightning-talk submission and voting tool on top of the existing 02ship.com Next.js app, with no database and no auth framework. Stores data in Vercel KV. Scoped to a single hardcoded event.
+Ship a mobile-first, QR-driven lightning-talk submission and voting tool inside the existing 02ship.com Next.js app. MVP is a single deployed event with config in the repo, no full auth framework, and mutable state stored in Vercel KV via `@vercel/kv`.
 
-## 2. Non-goals (explicit cuts from the PRD)
+## 2. Non-goals
 
 - Multi-event support
-- Full admin dashboard UI with filters and bulk actions (replaced by a minimal token-gated table)
-- Account system or OAuth (Discord, wallet, magic link)
-- Voter search/filter on the voting page
-- Voter vote editing
+- Runtime event-settings UI
+- Full admin dashboard UI with filters, bulk actions, or inline copy editing
+- Voter search / filter / sort controls
+- Vote editing after submission
 - Speaker submission editing
-- Comment system, speaker profiles, gamification, leaderboards
+- Public live vote counts
+- Public in-app results page
 - Runtime QR code generation
-- Live public vote counts
+- Account system or OAuth
+- Comment system, speaker profiles, gamification, or leaderboards
 
 ## 3. Architecture
 
-A single-event, mobile-first voting feature bolted onto the existing Next.js 14 / Vercel app. Write store is **Vercel KV**; event metadata is a JSON file committed to the repo.
+A single-event voting feature added to the existing Next.js 14 / Vercel app. Event metadata is a JSON file committed to the repo. Mutable submission and ballot data lives in Vercel KV.
 
 ```
 content/events/lightning-talk.json       # event config
+src/types/event.ts                       # typed event config
 src/app/submit/page.tsx                  # QR 1 target
 src/app/vote/page.tsx                    # QR 2 target
-src/app/admin/page.tsx                   # landing (token prompt)
+src/app/admin/page.tsx                   # token form / landing
 src/app/admin/submissions/page.tsx       # moderation queue
 src/app/admin/results/page.tsx           # ranked tally
 src/app/api/submissions/route.ts         # POST new submission
 src/app/api/votes/route.ts               # POST ballot
-src/app/api/admin/submissions/route.ts   # GET/PATCH (token)
-src/app/api/admin/results/route.ts       # GET (token)
-src/lib/voting.ts                        # KV + cookie helpers, tallyVotes
-src/lib/admin.ts                         # timing-safe token check
-src/middleware.ts                        # sets zts_voter cookie if missing
+src/app/api/admin/session/route.ts       # POST admin token -> session cookie
+src/app/api/admin/logout/route.ts        # POST clear admin session
+src/app/api/admin/submissions/route.ts   # GET/PATCH submissions
+src/app/api/admin/results/route.ts       # GET ranked results
+src/lib/voting.ts                        # KV access, validators, tally, shuffle helpers
+src/lib/admin.ts                         # token compare + signed session cookie helpers
+src/middleware.ts                        # best-effort zts_voter cookie seeding
 public/events/lightning-talk-qr-submit.png
 public/events/lightning-talk-qr-vote.png
 ```
 
-**End-to-end flow:**
-1. Organizer edits `content/events/lightning-talk.json` and deploys.
-2. Speaker scans QR 1 → `/submit` → POST `/api/submissions` → KV `submission:<id>` with `status: pending`.
-3. Organizer visits `/admin/submissions?token=...` → PATCH `/api/admin/submissions?id=<id>` → status → `approved`.
-4. Voter scans QR 2 → `/vote` → sees approved submissions in per-session-randomized order, no counts → selects up to `voteLimit` → POST `/api/votes` → KV `vote:<event>:<voterUuid>` = ballot.
-5. Organizer watches `/admin/results?token=...`. After `votingClosesAt`, publishes final list.
+Add `@vercel/kv` to the app dependencies. No separate backend service.
 
-**Design choices (locked in during brainstorming):**
+**End-to-end flow**
+1. Organizer edits `content/events/lightning-talk.json` and deploys.
+2. Speaker scans QR 1, opens `/submit`, and POSTs `/api/submissions`. Server writes `submission:<id>` with `status: "pending"`.
+3. Organizer opens `/admin`, submits the admin token once, receives a signed session cookie, and approves or rejects submissions from `/admin/submissions`.
+4. Voter scans QR 2, opens `/vote`, sees approved talks in neutral order, selects up to `voteLimit`, and POSTs `/api/votes`. Server writes a single ballot for that voter cookie.
+5. Organizer watches `/admin/results`, exports CSV, and announces the final agenda outside the app.
+
+**Locked design choices**
 - Vercel KV is the only write store.
-- Event config committed to the repo (git-versioned). Redeploy to change.
-- Anonymous voter identity via `httpOnly`, `SameSite=Lax` UUID cookie `zts_voter`, set by Next.js middleware on first request to any `/submit`, `/vote`, or `/api/{submissions,votes}` path. This guarantees the cookie exists before any page renders or any API handler runs, avoiding a race between the cookie-seeded shuffle and a cookieless first visit.
-- Organizer-only vote-count visibility to avoid popularity bias; voter sees cards in a per-session-randomized order seeded from the cookie.
-- Admin endpoints gated by `ADMIN_TOKEN` env var compared with `crypto.timingSafeEqual`.
-- Submission anti-spam: same cookie keys a 24h rate-limit counter, cap 3 submissions per browser.
+- Event config is git-versioned. Changing submission window, voting window, vote limit, or contact rule requires redeploy.
+- Anonymous voter identity uses an `httpOnly`, `SameSite=Lax` UUID cookie named `zts_voter`. Middleware seeds it best-effort on public paths, but pages and APIs must tolerate the cookie being missing on the first render.
+- Public voters never see vote counts. Approved cards are shown in neutral order; when `zts_voter` exists, order is deterministically shuffled from that seed for that browser.
+- Admin access uses a signed `httpOnly` session cookie (`zts_admin`) issued by `/api/admin/session`. No admin secret appears in the URL.
+- Submission anti-spam is browser-scoped with a 24-hour counter.
+- Ballots are write-once per voter cookie. Retrying the same ballot is idempotent; trying to change it after submission is rejected.
+- All pages and handlers that depend on current time, cookies, or KV use dynamic rendering and `no-store` fetch semantics. This feature must not be statically optimized.
 
 ## 4. Data model
 
-### 4.1 Event config (repo file)
+### 4.1 Event config
 
 `content/events/lightning-talk.json`:
 
@@ -72,179 +81,245 @@ public/events/lightning-talk-qr-vote.png
   "votingOpensAt": "2026-04-20T00:00:00Z",
   "votingClosesAt": "2026-04-27T23:59:00Z",
   "voteLimit": 3,
-  "submissionLimitPerCookie": 3
+  "submissionRateLimitPerCookie24h": 3,
+  "contactRule": "handle-or-contact"
 }
 ```
 
-Typed by a new `src/types/event.ts`. Loaded via `getEventConfig()` in `src/lib/voting.ts`.
+Typed by `src/types/event.ts` and loaded through `getEventConfig()` in `src/lib/voting.ts`.
 
 ### 4.2 Vercel KV keys
 
 | Key | Value shape | Purpose |
 |---|---|---|
 | `submission:<uuid>` | `{ id, event, speakerName, handle?, contact?, title, intro, tag?, status, createdAt }` | One submission. `status ∈ "pending" \| "approved" \| "rejected"`. |
-| `submissions:index:<event>` | `string[]` of submission IDs | Cheap iteration; append-only. |
-| `vote:<event>:<voterUuid>` | `string[]` of submission IDs, length ≤ `voteLimit` | Full ballot per voter. Overwrite is allowed (idempotent). |
-| `voters:index:<event>` | `string[]` of voter UUIDs | For `totalVoters` in results. |
-| `submit-rate:<cookieUuid>` | `number`, TTL 86400s | Submission counter per browser, 24h window. |
+| `submissions:set:<event>` | Redis set of submission IDs | Enumerate submissions without race-prone array appends. |
+| `vote:<event>:<voterUuid>` | `{ submissionIds: string[]; submittedAt: string }` | One immutable ballot per voter cookie. |
+| `voters:set:<event>` | Redis set of voter UUIDs | Stable `totalVoters` count with `SCARD`. |
+| `submit-rate:<event>:<cookieUuid>` | `number`, TTL 86400s | Submission counter per browser in a rolling 24-hour window. |
 
-**Rationale:**
-- Per-submission keys make status updates atomic single `SET`s.
-- Index keys work around KV's lack of `SCAN`.
-- Per-voter ballot key: one write per voter, idempotent overwrite, trivial future "edit before close".
-- No aggregated counters stored — `tallyVotes()` always computes — so counts can't drift.
+**Rationale**
+- Per-submission keys keep moderation updates atomic.
+- Redis sets avoid lost updates and duplicate IDs that would happen with read-modify-write array indexes.
+- One ballot key per voter preserves write-once semantics while still allowing idempotent retries.
+- Vote counts are always derived by `tallyVotes()`, so no aggregate counters can drift.
 
 ## 5. Routes and pages
 
 ### 5.1 Public pages
 
-- **`/submit`** — Server reads event config, renders `<SubmissionForm />` client component. Fields: `speakerName` (required), `handle` (optional), `contact` (optional), `title` (≤ 80 chars, required), `intro` (≤ 500 chars, required), `tag` (optional), `consent` (required checkbox). Top copy: "Submit a 5-minute talk idea" + event name + close time. Banner "Submissions are closed" when `now` is outside the submission window. On success, page state switches to "Thanks, your submission is under review."
-- **`/vote`** — Server fetches approved submissions from KV, shuffles with a seed stored in the voter cookie (so refresh keeps the same order for that voter), renders `<VoteClient />`. Voter taps up to `voteLimit` cards to toggle selection. "Submit vote" button POSTs ballot. After success, page state switches to confirmation with share CTAs. Banner "Voting is closed" outside window. No vote counts visible anywhere.
+- **`/submit`**  
+  Server component that reads event config and renders `<SubmissionForm />`. Required fields: `speakerName`, `title`, `intro`, `consent`. `handle` and `contact` are individually optional but at least one must be present. `title` max 80 chars, `intro` max 500 chars. Top copy includes event name and submission close time. Outside the window, the page remains viewable but the form is disabled and shows "Submissions are closed."
 
-### 5.2 Admin pages (token-gated)
+- **`/vote`**  
+  Server component that reads approved submissions plus the current ballot, if one exists. If the voter has already submitted a ballot, render a read-only confirmation state instead of the selection UI. Otherwise render `<VoteClient />`, which shows approved talks with no counts and lets the voter toggle up to `voteLimit` selections. The display order is seeded from `zts_voter` when available; if the first render has no cookie yet, use a request-scoped fallback seed and accept that a first refresh may reshuffle.
 
-All admin pages are server components that read `?token=` from the URL and compare it with `ADMIN_TOKEN` via `crypto.timingSafeEqual`. If missing or wrong, the page renders a "paste your token" form that GETs back to the same path with `?token=<input>`. Token stays in the URL on every navigation (admin bookmarks include it). Server components pass `token` as a prop to any client component that needs to issue mutations; those components include it in the `x-admin-token` header on `fetch`. No `sessionStorage`, no cookie, no client-side persistence of the token.
+### 5.2 Admin pages
 
-- **`/admin`** — Landing. On valid token, renders links to `/admin/submissions?token=...` and `/admin/results?token=...`.
-- **`/admin/submissions`** — Moderation queue. Table grouped by status (pending first). Each row: title, speaker, intro preview, tag, Approve / Reject / Reset-to-pending buttons. Buttons live in a client component that receives `token` as a prop and PATCHes `/api/admin/submissions?id=<id>` with `x-admin-token`. Header shows total submissions per status plus `totalVoters` and `totalVotes` snapshot (fetched server-side).
-- **`/admin/results`** — Ranked results table: rank (ties share), title, speaker, vote count, tag, status. "Voting closes in Xh" while open; "Final results" after close. "Download CSV" button generates a CSV client-side from data already on the page.
+Admin pages are protected by a signed `zts_admin` cookie. They never accept the admin token via query string.
+
+- **`/admin`**  
+  If no valid admin session cookie exists, render a token-entry form that `POST`s to `/api/admin/session`. On success, redirect to `/admin/submissions`. If a session exists, render links to the submissions queue and results page plus a sign-out button.
+
+- **`/admin/submissions`**  
+  Protected server component. Table grouped by status with pending first. Each row shows title, speaker, reachable contact, intro preview, tag, and actions: Approve, Reject, Reset to pending. Header includes per-status counts and a read-only summary of the configured submission window, voting window, and vote limit.
+
+- **`/admin/results`**  
+  Protected server component. Ranked table with rank, title, speaker, reachable contact, vote count, tag, and status. While voting is open, show the close timestamp; after close, show "Final ranking." "Download CSV" builds a client-side export from data already on the page, including contact info even if that column is visually collapsed on mobile.
 
 ### 5.3 QR codes
 
-Not a page. Generated once via any external QR generator from the full absolute URLs:
+Generated once from the production URLs:
 
 - `https://02ship.com/submit`
 - `https://02ship.com/vote`
 
-Saved as PNGs in `public/events/` and linked from a private Notion/doc. No runtime generation.
+Saved as static PNGs in `public/events/`. No runtime generation, no in-app QR management screen.
 
 ## 6. API endpoints
 
-All under `src/app/api/`. JSON in, JSON out. Most logic lives in `src/lib/voting.ts`; routes are thin.
+All routes live under `src/app/api/`. Most business logic stays in `src/lib/voting.ts` and `src/lib/admin.ts`; route handlers remain thin.
 
 ### 6.1 `POST /api/submissions`
 
 **Request body**
 ```ts
-{ speakerName: string; handle?: string; contact?: string;
-  title: string; intro: string; tag?: string; consent: boolean }
+{
+  speakerName: string;
+  handle?: string;
+  contact?: string;
+  title: string;
+  intro: string;
+  tag?: string;
+  consent: boolean;
+}
 ```
 
-**Validations (server-side, all enforced):**
+**Validations**
 - `event.submissionOpensAt <= now < event.submissionClosesAt`
-- `title.length` in `[1, 80]`
-- `intro.length` in `[1, 500]`
+- `speakerName`, `title`, and `intro` are non-empty after trim
+- `title.length <= 80`
+- `intro.length <= 500`
+- At least one of `handle` or `contact` is non-empty after trim
 - `consent === true`
-- `submit-rate:<cookieUuid>` < `event.submissionLimitPerCookie`
+- `zts_voter` cookie exists
+- `submit-rate:<event>:<cookieUuid>` is below `event.submissionRateLimitPerCookie24h`
 
-**Side effects (ordered):**
-1. Read `zts_voter` cookie (guaranteed set by middleware).
-2. `id = crypto.randomUUID()`.
-3. `SET submission:<id>` with `status: "pending"`, `createdAt: nowIso`.
-4. Append `id` to `submissions:index:<event>`.
-5. `INCR submit-rate:<cookieUuid>` and `EXPIRE 86400` on first hit.
+**Side effects**
+1. Read `zts_voter`.
+2. Generate `id = crypto.randomUUID()`.
+3. `SET submission:<id>` with `status: "pending"` and `createdAt`.
+4. `SADD submissions:set:<event> <id>`.
+5. `INCR submit-rate:<event>:<cookieUuid>` and set TTL to 86400 seconds on the first hit.
 
 **Responses**
 - `200 { ok: true, id }`
-- `400 { ok: false, error: "validation" | "closed" | "rate-limited" }`
+- `400 { ok: false, error: "validation" | "closed" | "cookies-required" }`
+- `429 { ok: false, error: "rate-limited" }`
 
 ### 6.2 `POST /api/votes`
 
 **Request body**
 ```ts
-{ submissionIds: string[] }  // length 1..voteLimit
+{ submissionIds: string[] }
 ```
 
-**Validations:**
+**Validations**
+- `zts_voter` cookie exists
 - `event.votingOpensAt <= now < event.votingClosesAt`
-- `submissionIds.length` in `[1, voteLimit]`
-- No duplicates within the array.
-- Every id exists in KV AND `submission.status === "approved"`. Unknown or non-approved IDs: return `unknown-submission` (we do NOT silently drop in the normal vote path; see §7 for the post-hoc rejection edge case).
+- `submissionIds.length` is in `[1, voteLimit]`
+- No duplicates within `submissionIds`
+- Every ID currently exists and is `approved` during the initial validation pass
+- If `vote:<event>:<voterUuid>` already exists:
+  - same canonical submission set => treat as idempotent retry
+  - different canonical submission set => reject as `already-voted`
 
-**Side effects (ordered):**
-1. Read `zts_voter` cookie (guaranteed set by middleware).
-2. `SET vote:<event>:<voterUuid>` = `submissionIds`.
-3. Add `voterUuid` to `voters:index:<event>` if new.
+**Side effects**
+1. Re-read the selected submissions immediately before writing.
+2. Keep only IDs that are still `approved`.
+3. If zero selections remain, return `409 selection-unavailable`.
+4. `SET vote:<event>:<voterUuid>` to `{ submissionIds: approvedIds, submittedAt: nowIso }`.
+5. `SADD voters:set:<event> <voterUuid>`.
 
 **Responses**
-- `200 { ok: true, recorded: submissionIds.length }`
-- `400 { ok: false, error: "validation" | "closed" | "unknown-submission" }`
+- `200 { ok: true, recorded: number, dropped?: number, alreadyRecorded?: true }`
+- `400 { ok: false, error: "validation" | "closed" | "cookies-required" | "unknown-submission" }`
+- `409 { ok: false, error: "already-voted" | "selection-unavailable" }`
 
-### 6.3 `GET|PATCH /api/admin/submissions`
+### 6.3 `POST /api/admin/session`
 
-Auth: header `x-admin-token` compared with `ADMIN_TOKEN` env var using `crypto.timingSafeEqual`.
+**Request body**
+```ts
+{ token: string }
+```
 
-- `GET /api/admin/submissions?status=pending|approved|rejected|all` → `{ submissions: Submission[] }`
-- `PATCH /api/admin/submissions?id=<uuid>` with body `{ status: "approved" | "rejected" | "pending" }` → `{ ok: true }`
-- `401` on missing/wrong token.
+**Behavior**
+- Compare the submitted token with `ADMIN_TOKEN` using a constant-time helper.
+- On success, set signed `httpOnly`, `secure`, `SameSite=Lax` cookie `zts_admin`.
+- Default session lifetime: 8 hours.
 
-### 6.4 `GET /api/admin/results`
+**Responses**
+- `204` on success
+- `401` on invalid token
 
-Auth: same.
+### 6.4 `POST /api/admin/logout`
+
+Clears `zts_admin` and redirects or returns `204`.
+
+### 6.5 `GET | PATCH /api/admin/submissions`
+
+Auth: valid `zts_admin` cookie required.
+
+- `GET /api/admin/submissions?status=pending|approved|rejected|all`  
+  Returns `{ submissions: Submission[] }`
+- `PATCH /api/admin/submissions?id=<uuid>` with body `{ status: "approved" | "rejected" | "pending" }`  
+  Returns `{ ok: true }`
+- `401` on missing or invalid admin session
+
+### 6.6 `GET /api/admin/results`
+
+Auth: valid `zts_admin` cookie required.
 
 **Response**
 ```ts
 {
-  totalVoters: number,
-  totalVotes: number,
+  totalVoters: number;
+  totalVotes: number;
   results: Array<{
-    id: string, title: string, speakerName: string,
-    handle?: string, tag?: string, status: Status,
-    voteCount: number, rank: number
-  }>
+    id: string;
+    title: string;
+    speakerName: string;
+    handle?: string;
+    contact?: string;
+    tag?: string;
+    status: "pending" | "approved" | "rejected";
+    voteCount: number;
+    rank: number;
+  }>;
 }
 ```
 
-Sorted by `voteCount` desc; ties share rank (1, 1, 3, ...).
+Sorted by `voteCount` descending. Ties share rank: `1, 1, 3`.
+Only currently approved submissions contribute to `voteCount`; pending and rejected rows remain visible to admins for context.
 
 ## 7. Error handling and edge cases
 
-**User-facing failures** (inline banner, never throw):
-- Submission outside window → "Submissions are closed" with close time.
-- Voting outside window → "Voting is closed. Results will be announced soon."
-- Submission rate-limited → "You've reached the limit of 3 submissions from this browser."
-- Cookies disabled → form POST fails because we can't identify the voter; show "Please enable cookies to vote" with a retry button.
+**User-facing failures**
+- Submission outside window => "Submissions are closed."
+- Missing reachable contact => "Add a public handle or contact info so organizers can reach you."
+- Submission rate-limited => "You've reached the limit of 3 submissions from this browser in 24 hours."
+- Missing cookie => "Please enable cookies and reload before submitting or voting."
+- Voting not open or already closed => show the approved talk list, disable submit controls, and display the relevant timestamp.
+- `already-voted` => "This browser has already submitted a ballot."
+- `selection-unavailable` => "Your selected talks changed while you were voting. Refresh and try again."
+- Partial drop (`dropped > 0`) => "Vote recorded, but some selections were no longer available."
 
-**Post-hoc rejection edge case** (organizer rejects a talk while a voter is choosing):
-- Server-side when saving the ballot: filter `submissionIds` to only those currently `approved`, persist the filtered array.
-- If anything was filtered, respond `200 { ok: true, recorded: N, dropped: M }`; client shows "Vote recorded (N of N+M counted — some selections were no longer available)."
-- This is the ONE case where we silently drop IDs; the normal-path validation in §6.2 still rejects IDs that were never approved.
+**Admin failures**
+- Missing or invalid admin session => redirect to `/admin`.
+- KV unavailable => render "Service temporarily unavailable, please retry." No silent retry loops.
 
-**Admin failures:**
-- Wrong/missing token → 401; admin pages render the "paste token" form.
-- KV unavailable → error boundary renders "Service temporarily unavailable, please retry." No auto-retry.
+**Race conditions we accept**
+- Two submissions or votes arriving at once => different primary keys; KV sets avoid index append races.
+- Two admin tabs changing the same submission => last write wins.
+- A talk changes out of `approved` while a voter is submitting => the server filters to currently approved selections right before writing, and `tallyVotes()` also ignores any non-approved submissions.
+- The same ballot is retried after a network hiccup => idempotent success if the submission set matches.
 
-**Race conditions we accept without locking:**
-- Two voters submit simultaneously → different keys, no lock needed.
-- Two admin tabs approve the same submission → last write wins.
-- Voter voted, admin later rejects a talk on their ballot → ballot key still contains the rejected ID, but `tallyVotes()` filters by `submission.status === "approved"`, so counts stay correct without rewriting ballots.
-
-**Explicit non-guards:**
-- Abuser clearing cookies to vote twice — accepted cost of cookie-only identity.
-- Replay of a submitted ballot via curl — same voterUuid = same key = idempotent overwrite.
+**Explicit non-guards**
+- Clearing cookies to vote twice. Accepted trade-off for cookie-only identity in MVP.
+- Any runtime change to event windows or vote limit without redeploy. Not supported.
 
 ## 8. Testing
 
-Intentionally lightweight for a short-lived, single-event tool.
+Keep the test surface small, but do not skip the integration points that are easiest to break.
 
-1. **Unit tests** at `src/lib/__tests__/voting.test.ts` (Vitest, matching existing setup) for pure functions:
+1. **Unit tests** in `src/lib/__tests__/voting.test.ts` for:
    - `isWithinWindow(opens, closes, now)`
-   - `tallyVotes(ballots, submissions)` — including the "rejected submission on ballot" case
-   - Ballot-shape validator (length, duplicates, unknown IDs)
-2. **Smoke script** at `scripts/smoke-voting.mjs` against a local dev server + scratch KV namespace: submit 3 talks → approve 2 via admin API → cast 2 ballots → fetch results, assert counts and rank order.
-3. **No E2E browser tests.** Two forms and a table; manual QA on a real phone for 10 minutes before the event is cheaper and higher-signal than Playwright here.
+   - ballot validation
+   - canonical ballot comparison
+   - `tallyVotes(ballots, submissions)` including non-approved-submission filtering
+2. **Unit tests** in `src/lib/__tests__/admin.test.ts` for:
+   - token comparison helper
+   - admin session cookie signing / verification
+3. **One Playwright smoke spec** in `e2e/lightning-talk-voting.spec.ts` covering:
+   - submit a talk
+   - approve it through admin session flow
+   - cast a ballot once
+   - verify the ballot cannot be changed
+   - verify the approved talk appears in admin results
 
 ## 9. Environment variables
 
 | Var | Purpose | Where |
 |---|---|---|
-| `KV_REST_API_URL` | Vercel KV | Vercel project env (auto-set when KV linked) |
-| `KV_REST_API_TOKEN` | Vercel KV | Vercel project env (auto-set when KV linked) |
-| `ADMIN_TOKEN` | Moderator auth | Set manually in Vercel project env; share out-of-band |
+| `KV_REST_API_URL` | Vercel KV | Vercel project env |
+| `KV_REST_API_TOKEN` | Vercel KV | Vercel project env |
+| `ADMIN_TOKEN` | Admin login token and admin-session signing secret | Vercel project env |
 
-## 10. Open operational notes
+## 10. Operational notes
 
-- The organizer needs a strong random `ADMIN_TOKEN` (e.g., 32 bytes base64) set before launch.
-- KV must be provisioned and linked to the Vercel project before the first write.
-- QR codes need to be regenerated if the production domain changes.
-- After the event, `content/events/lightning-talk.json` can stay in the repo as an archived record; KV data can be purged with a one-off `scripts/purge-event.mjs` if desired.
+- Add `@vercel/kv` before implementation. The current repo does not include it yet.
+- Set a strong random `ADMIN_TOKEN` before launch.
+- Provision and link Vercel KV before the first write.
+- Because event config is repo-backed, any change to windows, vote limit, or contact rule requires redeploy.
+- Regenerate QR codes if the production domain changes.
+- After the event, keep `content/events/lightning-talk.json` as an archive and purge KV data with a one-off script if desired.

--- a/e2e/lightning-talk-voting.spec.ts
+++ b/e2e/lightning-talk-voting.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, request } from '@playwright/test';
+
+const ADMIN_TOKEN = process.env.E2E_ADMIN_TOKEN ?? 'change-me-matching-ADMIN_TOKEN';
+
+test('speaker submits, admin approves, voter votes once, already-voted on retry', async ({
+  page,
+  baseURL,
+}) => {
+  // Speaker: open /submit and submit a talk
+  await page.goto('/submit');
+  await page.fill('input[name="speakerName"]', 'E2E Speaker');
+  await page.fill('input[name="handle"]', '@e2e');
+  await page.fill('input[name="title"]', 'E2E Lightning Talk');
+  await page.fill('textarea[name="intro"]', 'A short test intro for the end-to-end smoke.');
+  await page.check('input[name="consent"]');
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/submissions') && r.request().method() === 'POST'),
+    page.click('button[type="submit"]'),
+  ]);
+  await expect(page.getByText('Thanks — your talk is under review.')).toBeVisible();
+
+  // Admin: log in, find pending submission, approve it
+  const ctx = await request.newContext({ baseURL });
+  const login = await ctx.post('/api/admin/session', { data: { token: ADMIN_TOKEN } });
+  expect(login.status()).toBe(204);
+
+  const list = await ctx.get('/api/admin/submissions?status=pending');
+  expect(list.ok()).toBe(true);
+  const pendingBody = await list.json();
+  const target = pendingBody.submissions.find((s: { title: string; id: string }) =>
+    s.title === 'E2E Lightning Talk'
+  );
+  expect(target).toBeTruthy();
+  const patch = await ctx.patch(`/api/admin/submissions?id=${target.id}`, {
+    data: { status: 'approved' },
+  });
+  expect(patch.ok()).toBe(true);
+
+  // Voter: open /vote and cast a ballot for the approved talk
+  await page.goto('/vote');
+  await page.getByRole('button', { name: /E2E Lightning Talk/ }).click();
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/votes') && r.request().method() === 'POST'),
+    page.getByRole('button', { name: /Submit vote/ }).click(),
+  ]);
+  await expect(page.getByText(/your vote has been recorded/i)).toBeVisible();
+
+  // Reload /vote -- should now show "already voted" state
+  await page.goto('/vote');
+  await expect(page.getByText(/already voted from this browser/i)).toBeVisible();
+
+  // Admin: results should include the approved talk with voteCount >= 1
+  const results = await ctx.get('/api/admin/results');
+  expect(results.ok()).toBe(true);
+  const resultsBody = await results.json();
+  const row = resultsBody.results.find((r: { id: string }) => r.id === target.id);
+  expect(row).toBeTruthy();
+  expect(row.voteCount).toBeGreaterThanOrEqual(1);
+});

--- a/e2e/lightning-talk-voting.spec.ts
+++ b/e2e/lightning-talk-voting.spec.ts
@@ -2,26 +2,18 @@ import { test, expect, request } from '@playwright/test';
 
 const ADMIN_TOKEN = process.env.E2E_ADMIN_TOKEN ?? '';
 
-// Skip unless the voting feature's env is actually configured. Running this
-// spec requires Vercel KV to be reachable (so submissions and ballots persist)
-// and the admin token to match the one used by the app.
-const CAN_RUN = Boolean(
-  ADMIN_TOKEN && process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN
-);
-
 test('speaker submits, admin approves, voter votes once, already-voted on retry', async ({
   page,
   baseURL,
 }) => {
-  test.skip(
-    !CAN_RUN,
-    'Set ADMIN_TOKEN (and E2E_ADMIN_TOKEN), KV_REST_API_URL, KV_REST_API_TOKEN to run this spec.'
-  );
+  // Unique per run so repeated CI runs against the same KV do not collide.
+  const uniqueTitle = `E2E Lightning Talk ${Date.now()}`;
+
   // Speaker: open /submit and submit a talk
   await page.goto('/submit');
   await page.fill('input[name="speakerName"]', 'E2E Speaker');
   await page.fill('input[name="handle"]', '@e2e');
-  await page.fill('input[name="title"]', 'E2E Lightning Talk');
+  await page.fill('input[name="title"]', uniqueTitle);
   await page.fill('textarea[name="intro"]', 'A short test intro for the end-to-end smoke.');
   await page.check('input[name="consent"]');
   await Promise.all([
@@ -39,7 +31,7 @@ test('speaker submits, admin approves, voter votes once, already-voted on retry'
   expect(list.ok()).toBe(true);
   const pendingBody = await list.json();
   const target = pendingBody.submissions.find((s: { title: string; id: string }) =>
-    s.title === 'E2E Lightning Talk'
+    s.title === uniqueTitle
   );
   expect(target).toBeTruthy();
   const patch = await ctx.patch(`/api/admin/submissions?id=${target.id}`, {
@@ -49,7 +41,7 @@ test('speaker submits, admin approves, voter votes once, already-voted on retry'
 
   // Voter: open /vote and cast a ballot for the approved talk
   await page.goto('/vote');
-  await page.getByRole('button', { name: /E2E Lightning Talk/ }).click();
+  await page.getByRole('button', { name: new RegExp(uniqueTitle) }).click();
   await Promise.all([
     page.waitForResponse((r) => r.url().includes('/api/votes') && r.request().method() === 'POST'),
     page.getByRole('button', { name: /Submit vote/ }).click(),

--- a/e2e/lightning-talk-voting.spec.ts
+++ b/e2e/lightning-talk-voting.spec.ts
@@ -1,11 +1,22 @@
 import { test, expect, request } from '@playwright/test';
 
-const ADMIN_TOKEN = process.env.E2E_ADMIN_TOKEN ?? 'change-me-matching-ADMIN_TOKEN';
+const ADMIN_TOKEN = process.env.E2E_ADMIN_TOKEN ?? '';
+
+// Skip unless the voting feature's env is actually configured. Running this
+// spec requires Vercel KV to be reachable (so submissions and ballots persist)
+// and the admin token to match the one used by the app.
+const CAN_RUN = Boolean(
+  ADMIN_TOKEN && process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN
+);
 
 test('speaker submits, admin approves, voter votes once, already-voted on retry', async ({
   page,
   baseURL,
 }) => {
+  test.skip(
+    !CAN_RUN,
+    'Set ADMIN_TOKEN (and E2E_ADMIN_TOKEN), KV_REST_API_URL, KV_REST_API_TOKEN to run this spec.'
+  );
   // Speaker: open /submit and submit a talk
   await page.goto('/submit');
   await page.fill('input[name="speakerName"]', 'E2E Speaker');

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "zero-to-ship",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/kv": "^3.0.0",
         "clsx": "^2.1.1",
         "fast-xml-parser": "^5.5.5",
         "gray-matter": "^4.0.3",
@@ -1986,6 +1987,28 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@vercel/kv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
+      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
+      "deprecated": "Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@upstash/redis": "^1.34.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -9392,6 +9415,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.24.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@vercel/kv": "^3.0.0",
     "clsx": "^2.1.1",
     "fast-xml-parser": "^5.5.5",
     "gray-matter": "^4.0.3",

--- a/src/app/admin/AdminLoginForm.tsx
+++ b/src/app/admin/AdminLoginForm.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+
+export function AdminLoginForm() {
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'error'>('idle');
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus('submitting');
+    const fd = new FormData(e.currentTarget);
+    const token = String(fd.get('token') ?? '');
+    const res = await fetch('/api/admin/session', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    if (res.status === 204) {
+      window.location.href = '/admin/submissions';
+      return;
+    }
+    setStatus('error');
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Admin token</span>
+        <input
+          name="token"
+          type="password"
+          required
+          className="w-full rounded border border-neutral-300 p-2"
+          autoComplete="off"
+        />
+      </label>
+      {status === 'error' && (
+        <p role="alert" className="text-sm text-red-700">
+          Invalid token.
+        </p>
+      )}
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+      >
+        {status === 'submitting' ? 'Signing in…' : 'Sign in'}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/AdminLoginForm.tsx
+++ b/src/app/admin/AdminLoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
 
 export function AdminLoginForm() {
   const [status, setStatus] = useState<'idle' | 'submitting' | 'error'>('idle');
@@ -23,29 +24,25 @@ export function AdminLoginForm() {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-3">
+    <form onSubmit={onSubmit} className="space-y-4">
       <label className="block">
-        <span className="mb-1 block text-sm font-medium">Admin token</span>
+        <span className="mb-1.5 block text-sm font-medium text-gray-900">Admin token</span>
         <input
           name="token"
           type="password"
           required
-          className="w-full rounded border border-neutral-300 p-2"
-          autoComplete="off"
+          autoComplete="new-password"
+          className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-sm placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600"
         />
       </label>
       {status === 'error' && (
-        <p role="alert" className="text-sm text-red-700">
+        <p role="alert" className="text-sm font-medium text-red-700">
           Invalid token.
         </p>
       )}
-      <button
-        type="submit"
-        disabled={status === 'submitting'}
-        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
-      >
+      <Button type="submit" disabled={status === 'submitting'} className="w-full">
         {status === 'submitting' ? 'Signing in…' : 'Sign in'}
-      </button>
+      </Button>
     </form>
   );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { cookies } from 'next/headers';
 import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import { Container } from '@/components/ui/Container';
 import { AdminLoginForm } from './AdminLoginForm';
 
 export const dynamic = 'force-dynamic';
@@ -11,33 +12,66 @@ export default function AdminPage() {
 
   if (!authed) {
     return (
-      <div className="mx-auto max-w-sm px-4 py-10">
-        <h1 className="mb-4 text-2xl font-semibold">Admin sign-in</h1>
-        <AdminLoginForm />
-      </div>
+      <section className="py-16 sm:py-20">
+        <Container>
+          <div className="mx-auto max-w-sm">
+            <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              Admin sign-in
+            </h1>
+            <p className="mt-3 text-sm text-gray-600">
+              Enter the admin token to moderate submissions and view results.
+            </p>
+            <div className="mt-8">
+              <AdminLoginForm />
+            </div>
+          </div>
+        </Container>
+      </section>
     );
   }
 
   return (
-    <div className="mx-auto max-w-lg px-4 py-10">
-      <h1 className="mb-4 text-2xl font-semibold">Admin</h1>
-      <ul className="space-y-2">
-        <li>
-          <Link className="text-blue-700 underline" href="/admin/submissions">
-            Submissions queue
-          </Link>
-        </li>
-        <li>
-          <Link className="text-blue-700 underline" href="/admin/results">
-            Results
-          </Link>
-        </li>
-      </ul>
-      <form action="/api/admin/logout" method="post" className="mt-6">
-        <button type="submit" className="text-sm text-neutral-600 underline">
-          Sign out
-        </button>
-      </form>
-    </div>
+    <section className="py-16 sm:py-20">
+      <Container>
+        <div className="mx-auto max-w-xl">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Admin</h1>
+          <p className="mt-3 text-sm text-gray-600">
+            Moderate submissions and view ranked voting results.
+          </p>
+          <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <Link
+              href="/admin/submissions"
+              className="group rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition hover:border-gray-300 hover:shadow-md"
+            >
+              <h2 className="text-lg font-semibold text-gray-900 group-hover:text-blue-700">
+                Submissions queue →
+              </h2>
+              <p className="mt-2 text-sm text-gray-600">
+                Approve or reject pending talks.
+              </p>
+            </Link>
+            <Link
+              href="/admin/results"
+              className="group rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition hover:border-gray-300 hover:shadow-md"
+            >
+              <h2 className="text-lg font-semibold text-gray-900 group-hover:text-blue-700">
+                Results →
+              </h2>
+              <p className="mt-2 text-sm text-gray-600">
+                Ranked tally and CSV export.
+              </p>
+            </Link>
+          </div>
+          <form action="/api/admin/logout" method="post" className="mt-8">
+            <button
+              type="submit"
+              className="text-sm font-medium text-gray-500 underline-offset-4 hover:text-gray-900 hover:underline"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </Container>
+    </section>
   );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+import { cookies } from 'next/headers';
+import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import { AdminLoginForm } from './AdminLoginForm';
+
+export const dynamic = 'force-dynamic';
+
+export default function AdminPage() {
+  const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+  const authed = verifySession(session, Date.now());
+
+  if (!authed) {
+    return (
+      <div className="mx-auto max-w-sm px-4 py-10">
+        <h1 className="mb-4 text-2xl font-semibold">Admin sign-in</h1>
+        <AdminLoginForm />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-10">
+      <h1 className="mb-4 text-2xl font-semibold">Admin</h1>
+      <ul className="space-y-2">
+        <li>
+          <Link className="text-blue-700 underline" href="/admin/submissions">
+            Submissions queue
+          </Link>
+        </li>
+        <li>
+          <Link className="text-blue-700 underline" href="/admin/results">
+            Results
+          </Link>
+        </li>
+      </ul>
+      <form action="/api/admin/logout" method="post" className="mt-6">
+        <button type="submit" className="text-sm text-neutral-600 underline">
+          Sign out
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/admin/results/ResultsExport.tsx
+++ b/src/app/admin/results/ResultsExport.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Button } from '@/components/ui/Button';
+
 interface Row {
   rank: number;
   title: string;
@@ -44,8 +46,8 @@ export function ResultsExport({ rows, filename }: { rows: Row[]; filename: strin
   }
 
   return (
-    <button type="button" onClick={download} className="rounded bg-black px-3 py-1 text-sm text-white">
+    <Button type="button" size="sm" onClick={download}>
       Download CSV
-    </button>
+    </Button>
   );
 }

--- a/src/app/admin/results/ResultsExport.tsx
+++ b/src/app/admin/results/ResultsExport.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+interface Row {
+  rank: number;
+  title: string;
+  speakerName: string;
+  handle?: string;
+  contact?: string;
+  tag?: string;
+  status: string;
+  voteCount: number;
+}
+
+function csvEscape(v: string): string {
+  if (/[",\n]/.test(v)) return `"${v.replace(/"/g, '""')}"`;
+  return v;
+}
+
+export function ResultsExport({ rows, filename }: { rows: Row[]; filename: string }) {
+  function download() {
+    const header = ['rank', 'title', 'speaker', 'handle', 'contact', 'tag', 'status', 'voteCount'];
+    const lines = [header.join(',')];
+    for (const r of rows) {
+      lines.push(
+        [
+          String(r.rank),
+          csvEscape(r.title),
+          csvEscape(r.speakerName),
+          csvEscape(r.handle ?? ''),
+          csvEscape(r.contact ?? ''),
+          csvEscape(r.tag ?? ''),
+          r.status,
+          String(r.voteCount),
+        ].join(',')
+      );
+    }
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <button type="button" onClick={download} className="rounded bg-black px-3 py-1 text-sm text-white">
+      Download CSV
+    </button>
+  );
+}

--- a/src/app/admin/results/page.tsx
+++ b/src/app/admin/results/page.tsx
@@ -1,18 +1,26 @@
 import { cookies } from 'next/headers';
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
 import {
   assignRanks,
   getEventConfig,
-  isWithinWindow,
   listBallots,
   listSubmissions,
   tallyVotes,
   voterCount,
 } from '@/lib/voting';
+import type { SubmissionStatus } from '@/types/voting';
+import { Container } from '@/components/ui/Container';
 import { ResultsExport } from './ResultsExport';
 
 export const dynamic = 'force-dynamic';
+
+const STATUS_BADGE: Record<SubmissionStatus, string> = {
+  pending: 'bg-amber-100 text-amber-900',
+  approved: 'bg-green-100 text-green-900',
+  rejected: 'bg-red-100 text-red-900',
+};
 
 export default async function AdminResultsPage() {
   const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
@@ -28,62 +36,111 @@ export default async function AdminResultsPage() {
   const counts = tallyVotes(ballots, approvedIds);
   const totalVotes = ballots.reduce((n, b) => n + b.submissionIds.length, 0);
   const rows = assignRanks(subs.map((s) => ({ ...s, voteCount: counts.get(s.id) ?? 0 })));
-  const votingOpen = isWithinWindow(event.votingOpensAt, event.votingClosesAt, new Date());
+  const votingOpen = Date.now() < new Date(event.votingClosesAt).getTime();
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-10">
-      <div className="mb-4 flex items-baseline justify-between gap-4">
-        <h1 className="text-2xl font-semibold">Results</h1>
-        <ResultsExport
-          rows={rows.map((r) => ({
-            rank: r.rank,
-            title: r.title,
-            speakerName: r.speakerName,
-            handle: r.handle,
-            contact: r.contact,
-            tag: r.tag,
-            status: r.status,
-            voteCount: r.voteCount,
-          }))}
-          filename={`${event.slug}-results.csv`}
-        />
-      </div>
-      <p className="mb-6 text-sm text-neutral-600">
-        {event.name} ·{' '}
-        {votingOpen
-          ? `voting closes ${new Date(event.votingClosesAt).toLocaleString()}`
-          : 'Final ranking'}{' '}
-        · voters {totalVoters} · total votes {totalVotes}
-      </p>
-      <table className="w-full border-collapse text-sm">
-        <thead>
-          <tr className="border-b text-left">
-            <th className="py-2 pr-4">Rank</th>
-            <th className="py-2 pr-4">Title</th>
-            <th className="py-2 pr-4">Speaker</th>
-            <th className="py-2 pr-4">Contact</th>
-            <th className="py-2 pr-4">Tag</th>
-            <th className="py-2 pr-4">Status</th>
-            <th className="py-2 pr-4">Votes</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((r) => (
-            <tr key={r.id} className="border-b align-top">
-              <td className="py-2 pr-4">{r.rank}</td>
-              <td className="py-2 pr-4 font-medium">{r.title}</td>
-              <td className="py-2 pr-4">
-                {r.speakerName}
-                {r.handle ? ` · ${r.handle}` : ''}
-              </td>
-              <td className="py-2 pr-4 text-neutral-700">{r.contact ?? ''}</td>
-              <td className="py-2 pr-4">{r.tag ?? ''}</td>
-              <td className="py-2 pr-4">{r.status}</td>
-              <td className="py-2 pr-4">{r.voteCount}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <section className="py-12 sm:py-16">
+      <Container>
+        <div className="mx-auto max-w-5xl">
+          <div className="flex flex-wrap items-baseline justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+                Results
+              </h1>
+              <p className="mt-2 text-sm text-gray-600">
+                {event.name} ·{' '}
+                {votingOpen
+                  ? `voting closes ${new Date(event.votingClosesAt).toLocaleString()}`
+                  : 'Final ranking'}
+              </p>
+            </div>
+            <div className="flex items-center gap-4">
+              <Link
+                href="/admin/submissions"
+                className="text-sm font-medium text-blue-700 hover:text-blue-900"
+              >
+                ← Submissions
+              </Link>
+              <ResultsExport
+                rows={rows.map((r) => ({
+                  rank: r.rank,
+                  title: r.title,
+                  speakerName: r.speakerName,
+                  handle: r.handle,
+                  contact: r.contact,
+                  tag: r.tag,
+                  status: r.status,
+                  voteCount: r.voteCount,
+                }))}
+                filename={`${event.slug}-results.csv`}
+              />
+            </div>
+          </div>
+
+          <dl className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+              <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Voters</dt>
+              <dd className="mt-1 text-2xl font-bold text-gray-900">{totalVoters}</dd>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+              <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Total votes</dt>
+              <dd className="mt-1 text-2xl font-bold text-gray-900">{totalVotes}</dd>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+              <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Approved talks</dt>
+              <dd className="mt-1 text-2xl font-bold text-gray-900">{approvedIds.size}</dd>
+            </div>
+          </dl>
+
+          <div className="mt-10 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <table className="w-full border-collapse text-sm">
+              <thead className="bg-gray-50">
+                <tr className="text-left">
+                  <th className="px-4 py-3 font-medium text-gray-700">Rank</th>
+                  <th className="px-4 py-3 font-medium text-gray-700">Title</th>
+                  <th className="px-4 py-3 font-medium text-gray-700">Speaker</th>
+                  <th className="px-4 py-3 font-medium text-gray-700">Contact</th>
+                  <th className="px-4 py-3 font-medium text-gray-700">Status</th>
+                  <th className="px-4 py-3 text-right font-medium text-gray-700">Votes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {rows.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-6 text-center text-sm text-gray-500">
+                      No submissions yet.
+                    </td>
+                  </tr>
+                ) : (
+                  rows.map((r) => (
+                    <tr key={r.id} className="align-top">
+                      <td className="px-4 py-3 font-mono text-sm text-gray-900">
+                        {r.status === 'approved' ? r.rank : '—'}
+                      </td>
+                      <td className="px-4 py-3 font-medium text-gray-900">{r.title}</td>
+                      <td className="px-4 py-3 text-gray-700">
+                        <div>{r.speakerName}</div>
+                        {r.handle && <div className="text-xs text-gray-500">{r.handle}</div>}
+                      </td>
+                      <td className="px-4 py-3 text-gray-600">{r.contact ?? '—'}</td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${STATUS_BADGE[r.status]}`}
+                        >
+                          {r.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-right font-semibold text-gray-900">
+                        {r.voteCount}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </Container>
+    </section>
   );
 }

--- a/src/app/admin/results/page.tsx
+++ b/src/app/admin/results/page.tsx
@@ -1,0 +1,104 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import {
+  getEventConfig,
+  isWithinWindow,
+  listBallots,
+  listSubmissions,
+  tallyVotes,
+  voterCount,
+} from '@/lib/voting';
+import type { Submission } from '@/types/voting';
+import { ResultsExport } from './ResultsExport';
+
+export const dynamic = 'force-dynamic';
+
+function assignRanks(rows: Array<Submission & { voteCount: number }>) {
+  const sorted = [...rows].sort((a, b) => b.voteCount - a.voteCount);
+  let rank = 0;
+  let lastCount = -1;
+  let seen = 0;
+  return sorted.map((r) => {
+    seen += 1;
+    if (r.voteCount !== lastCount) {
+      rank = seen;
+      lastCount = r.voteCount;
+    }
+    return { ...r, rank };
+  });
+}
+
+export default async function AdminResultsPage() {
+  const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+  if (!verifySession(session, Date.now())) redirect('/admin');
+
+  const event = await getEventConfig();
+  const [subs, ballots, totalVoters] = await Promise.all([
+    listSubmissions(event.slug),
+    listBallots(event.slug),
+    voterCount(event.slug),
+  ]);
+  const approvedIds = new Set(subs.filter((s) => s.status === 'approved').map((s) => s.id));
+  const counts = tallyVotes(ballots, approvedIds);
+  const totalVotes = ballots.reduce((n, b) => n + b.submissionIds.length, 0);
+  const rows = assignRanks(subs.map((s) => ({ ...s, voteCount: counts.get(s.id) ?? 0 })));
+  const votingOpen = isWithinWindow(event.votingOpensAt, event.votingClosesAt, new Date());
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <div className="mb-4 flex items-baseline justify-between gap-4">
+        <h1 className="text-2xl font-semibold">Results</h1>
+        <ResultsExport
+          rows={rows.map((r) => ({
+            rank: r.rank,
+            title: r.title,
+            speakerName: r.speakerName,
+            handle: r.handle,
+            contact: r.contact,
+            tag: r.tag,
+            status: r.status,
+            voteCount: r.voteCount,
+          }))}
+          filename={`${event.slug}-results.csv`}
+        />
+      </div>
+      <p className="mb-6 text-sm text-neutral-600">
+        {event.name} ·{' '}
+        {votingOpen
+          ? `voting closes ${new Date(event.votingClosesAt).toLocaleString()}`
+          : 'Final ranking'}{' '}
+        · voters {totalVoters} · total votes {totalVotes}
+      </p>
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="py-2 pr-4">Rank</th>
+            <th className="py-2 pr-4">Title</th>
+            <th className="py-2 pr-4">Speaker</th>
+            <th className="py-2 pr-4">Contact</th>
+            <th className="py-2 pr-4">Tag</th>
+            <th className="py-2 pr-4">Status</th>
+            <th className="py-2 pr-4">Votes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id} className="border-b align-top">
+              <td className="py-2 pr-4">{r.rank}</td>
+              <td className="py-2 pr-4 font-medium">{r.title}</td>
+              <td className="py-2 pr-4">
+                {r.speakerName}
+                {r.handle ? ` · ${r.handle}` : ''}
+              </td>
+              <td className="py-2 pr-4 text-neutral-700">{r.contact ?? ''}</td>
+              <td className="py-2 pr-4">{r.tag ?? ''}</td>
+              <td className="py-2 pr-4">{r.status}</td>
+              <td className="py-2 pr-4">{r.voteCount}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/admin/results/page.tsx
+++ b/src/app/admin/results/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
 import {
+  assignRanks,
   getEventConfig,
   isWithinWindow,
   listBallots,
@@ -9,25 +10,9 @@ import {
   tallyVotes,
   voterCount,
 } from '@/lib/voting';
-import type { Submission } from '@/types/voting';
 import { ResultsExport } from './ResultsExport';
 
 export const dynamic = 'force-dynamic';
-
-function assignRanks(rows: Array<Submission & { voteCount: number }>) {
-  const sorted = [...rows].sort((a, b) => b.voteCount - a.voteCount);
-  let rank = 0;
-  let lastCount = -1;
-  let seen = 0;
-  return sorted.map((r) => {
-    seen += 1;
-    if (r.voteCount !== lastCount) {
-      rank = seen;
-      lastCount = r.voteCount;
-    }
-    return { ...r, rank };
-  });
-}
 
 export default async function AdminResultsPage() {
   const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;

--- a/src/app/admin/submissions/SubmissionActions.tsx
+++ b/src/app/admin/submissions/SubmissionActions.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+type Status = 'pending' | 'approved' | 'rejected';
+
+export function SubmissionActions({ id, current }: { id: string; current: Status }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function set(status: Status) {
+    setBusy(true);
+    const res = await fetch(`/api/admin/submissions?id=${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    setBusy(false);
+    if (res.ok) router.refresh();
+    else alert('Update failed.');
+  }
+
+  return (
+    <div className="flex gap-2">
+      <button
+        type="button"
+        disabled={busy || current === 'approved'}
+        onClick={() => set('approved')}
+        className="rounded bg-green-700 px-2 py-1 text-xs text-white disabled:opacity-50"
+      >
+        Approve
+      </button>
+      <button
+        type="button"
+        disabled={busy || current === 'rejected'}
+        onClick={() => set('rejected')}
+        className="rounded bg-red-700 px-2 py-1 text-xs text-white disabled:opacity-50"
+      >
+        Reject
+      </button>
+      <button
+        type="button"
+        disabled={busy || current === 'pending'}
+        onClick={() => set('pending')}
+        className="rounded bg-neutral-700 px-2 py-1 text-xs text-white disabled:opacity-50"
+      >
+        Reset
+      </button>
+    </div>
+  );
+}

--- a/src/app/admin/submissions/SubmissionActions.tsx
+++ b/src/app/admin/submissions/SubmissionActions.tsx
@@ -5,6 +5,9 @@ import { useRouter } from 'next/navigation';
 
 type Status = 'pending' | 'approved' | 'rejected';
 
+const baseBtn =
+  'inline-flex items-center rounded-lg px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
+
 export function SubmissionActions({ id, current }: { id: string; current: Status }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
@@ -22,12 +25,12 @@ export function SubmissionActions({ id, current }: { id: string; current: Status
   }
 
   return (
-    <div className="flex gap-2">
+    <div className="flex flex-wrap gap-1.5">
       <button
         type="button"
         disabled={busy || current === 'approved'}
         onClick={() => set('approved')}
-        className="rounded bg-green-700 px-2 py-1 text-xs text-white disabled:opacity-50"
+        className={`${baseBtn} bg-green-600 text-white hover:bg-green-700 focus-visible:ring-green-600`}
       >
         Approve
       </button>
@@ -35,7 +38,7 @@ export function SubmissionActions({ id, current }: { id: string; current: Status
         type="button"
         disabled={busy || current === 'rejected'}
         onClick={() => set('rejected')}
-        className="rounded bg-red-700 px-2 py-1 text-xs text-white disabled:opacity-50"
+        className={`${baseBtn} bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-600`}
       >
         Reject
       </button>
@@ -43,7 +46,7 @@ export function SubmissionActions({ id, current }: { id: string; current: Status
         type="button"
         disabled={busy || current === 'pending'}
         onClick={() => set('pending')}
-        className="rounded bg-neutral-700 px-2 py-1 text-xs text-white disabled:opacity-50"
+        className={`${baseBtn} border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus-visible:ring-gray-500`}
       >
         Reset
       </button>

--- a/src/app/admin/submissions/page.tsx
+++ b/src/app/admin/submissions/page.tsx
@@ -1,0 +1,79 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import { getEventConfig, listSubmissions, voterCount, listBallots } from '@/lib/voting';
+import type { Submission, SubmissionStatus } from '@/types/voting';
+import { SubmissionActions } from './SubmissionActions';
+
+export const dynamic = 'force-dynamic';
+
+const ORDER: SubmissionStatus[] = ['pending', 'approved', 'rejected'];
+
+function groupByStatus(list: Submission[]): Record<SubmissionStatus, Submission[]> {
+  const out: Record<SubmissionStatus, Submission[]> = { pending: [], approved: [], rejected: [] };
+  for (const s of list) out[s.status].push(s);
+  return out;
+}
+
+export default async function AdminSubmissionsPage() {
+  const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+  if (!verifySession(session, Date.now())) redirect('/admin');
+
+  const event = await getEventConfig();
+  const [all, totalVoters, ballots] = await Promise.all([
+    listSubmissions(event.slug),
+    voterCount(event.slug),
+    listBallots(event.slug),
+  ]);
+  const totalVotes = ballots.reduce((n, b) => n + b.submissionIds.length, 0);
+  const grouped = groupByStatus(all);
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <h1 className="mb-2 text-2xl font-semibold">Submissions</h1>
+      <p className="mb-6 text-sm text-neutral-600">
+        {event.name} · submissions close {new Date(event.submissionClosesAt).toLocaleString()} · voting closes{' '}
+        {new Date(event.votingClosesAt).toLocaleString()} · vote limit {event.voteLimit} · voters {totalVoters} ·
+        total votes {totalVotes}
+      </p>
+      {ORDER.map((status) => (
+        <section key={status} className="mb-8">
+          <h2 className="mb-2 text-lg font-semibold capitalize">
+            {status} ({grouped[status].length})
+          </h2>
+          {grouped[status].length === 0 ? (
+            <p className="text-sm text-neutral-600">None.</p>
+          ) : (
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="py-2 pr-4">Title</th>
+                  <th className="py-2 pr-4">Speaker</th>
+                  <th className="py-2 pr-4">Contact</th>
+                  <th className="py-2 pr-4">Intro</th>
+                  <th className="py-2 pr-4">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {grouped[status].map((s) => (
+                  <tr key={s.id} className="border-b align-top">
+                    <td className="py-2 pr-4 font-medium">{s.title}</td>
+                    <td className="py-2 pr-4">
+                      {s.speakerName}
+                      {s.handle ? ` · ${s.handle}` : ''}
+                    </td>
+                    <td className="py-2 pr-4 text-neutral-700">{s.contact ?? ''}</td>
+                    <td className="py-2 pr-4 text-neutral-700">{s.intro}</td>
+                    <td className="py-2 pr-4">
+                      <SubmissionActions id={s.id} current={s.status} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/app/admin/submissions/page.tsx
+++ b/src/app/admin/submissions/page.tsx
@@ -1,13 +1,21 @@
 import { cookies } from 'next/headers';
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
 import { getEventConfig, listSubmissions, voterCount, listBallots } from '@/lib/voting';
 import type { Submission, SubmissionStatus } from '@/types/voting';
+import { Container } from '@/components/ui/Container';
 import { SubmissionActions } from './SubmissionActions';
 
 export const dynamic = 'force-dynamic';
 
 const ORDER: SubmissionStatus[] = ['pending', 'approved', 'rejected'];
+
+const STATUS_BADGE: Record<SubmissionStatus, string> = {
+  pending: 'bg-amber-100 text-amber-900',
+  approved: 'bg-green-100 text-green-900',
+  rejected: 'bg-red-100 text-red-900',
+};
 
 function groupByStatus(list: Submission[]): Record<SubmissionStatus, Submission[]> {
   const out: Record<SubmissionStatus, Submission[]> = { pending: [], approved: [], rejected: [] };
@@ -29,51 +37,98 @@ export default async function AdminSubmissionsPage() {
   const grouped = groupByStatus(all);
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-10">
-      <h1 className="mb-2 text-2xl font-semibold">Submissions</h1>
-      <p className="mb-6 text-sm text-neutral-600">
-        {event.name} · submissions close {new Date(event.submissionClosesAt).toLocaleString()} · voting closes{' '}
-        {new Date(event.votingClosesAt).toLocaleString()} · vote limit {event.voteLimit} · voters {totalVoters} ·
-        total votes {totalVotes}
-      </p>
-      {ORDER.map((status) => (
-        <section key={status} className="mb-8">
-          <h2 className="mb-2 text-lg font-semibold capitalize">
-            {status} ({grouped[status].length})
-          </h2>
-          {grouped[status].length === 0 ? (
-            <p className="text-sm text-neutral-600">None.</p>
-          ) : (
-            <table className="w-full border-collapse text-sm">
-              <thead>
-                <tr className="border-b text-left">
-                  <th className="py-2 pr-4">Title</th>
-                  <th className="py-2 pr-4">Speaker</th>
-                  <th className="py-2 pr-4">Contact</th>
-                  <th className="py-2 pr-4">Intro</th>
-                  <th className="py-2 pr-4">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {grouped[status].map((s) => (
-                  <tr key={s.id} className="border-b align-top">
-                    <td className="py-2 pr-4 font-medium">{s.title}</td>
-                    <td className="py-2 pr-4">
-                      {s.speakerName}
-                      {s.handle ? ` · ${s.handle}` : ''}
-                    </td>
-                    <td className="py-2 pr-4 text-neutral-700">{s.contact ?? ''}</td>
-                    <td className="py-2 pr-4 text-neutral-700">{s.intro}</td>
-                    <td className="py-2 pr-4">
-                      <SubmissionActions id={s.id} current={s.status} />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </section>
-      ))}
-    </div>
+    <section className="py-12 sm:py-16">
+      <Container>
+        <div className="mx-auto max-w-5xl">
+          <div className="flex flex-wrap items-baseline justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+                Submissions
+              </h1>
+              <p className="mt-2 text-sm text-gray-600">{event.name}</p>
+            </div>
+            <Link
+              href="/admin/results"
+              className="text-sm font-medium text-blue-700 hover:text-blue-900"
+            >
+              View results →
+            </Link>
+          </div>
+
+          <dl className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+              <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Submissions close</dt>
+              <dd className="mt-1 text-sm font-semibold text-gray-900">
+                {new Date(event.submissionClosesAt).toLocaleString()}
+              </dd>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+              <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Voting closes</dt>
+              <dd className="mt-1 text-sm font-semibold text-gray-900">
+                {new Date(event.votingClosesAt).toLocaleString()}
+              </dd>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+              <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Voters</dt>
+              <dd className="mt-1 text-2xl font-bold text-gray-900">{totalVoters}</dd>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+              <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Total votes</dt>
+              <dd className="mt-1 text-2xl font-bold text-gray-900">{totalVotes}</dd>
+            </div>
+          </dl>
+
+          <div className="mt-10 space-y-10">
+            {ORDER.map((status) => (
+              <section key={status}>
+                <div className="flex items-center gap-3">
+                  <h2 className="text-xl font-semibold capitalize text-gray-900">{status}</h2>
+                  <span
+                    className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${STATUS_BADGE[status]}`}
+                  >
+                    {grouped[status].length}
+                  </span>
+                </div>
+                {grouped[status].length === 0 ? (
+                  <p className="mt-3 text-sm text-gray-500">None.</p>
+                ) : (
+                  <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+                    <table className="w-full border-collapse text-sm">
+                      <thead className="bg-gray-50">
+                        <tr className="text-left">
+                          <th className="px-4 py-3 font-medium text-gray-700">Title</th>
+                          <th className="px-4 py-3 font-medium text-gray-700">Speaker</th>
+                          <th className="px-4 py-3 font-medium text-gray-700">Contact</th>
+                          <th className="px-4 py-3 font-medium text-gray-700">Intro</th>
+                          <th className="px-4 py-3 font-medium text-gray-700">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-200">
+                        {grouped[status].map((s) => (
+                          <tr key={s.id} className="align-top">
+                            <td className="px-4 py-3 font-medium text-gray-900">{s.title}</td>
+                            <td className="px-4 py-3 text-gray-700">
+                              <div>{s.speakerName}</div>
+                              {s.handle && (
+                                <div className="text-xs text-gray-500">{s.handle}</div>
+                              )}
+                            </td>
+                            <td className="px-4 py-3 text-gray-600">{s.contact ?? '—'}</td>
+                            <td className="px-4 py-3 text-gray-600">{s.intro}</td>
+                            <td className="px-4 py-3">
+                              <SubmissionActions id={s.id} current={s.status} />
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </section>
+            ))}
+          </div>
+        </div>
+      </Container>
+    </section>
   );
 }

--- a/src/app/api/admin/logout/route.ts
+++ b/src/app/api/admin/logout/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { ADMIN_SESSION_COOKIE } from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  cookies().delete(ADMIN_SESSION_COOKIE);
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/admin/results/route.ts
+++ b/src/app/api/admin/results/route.ts
@@ -2,30 +2,15 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
 import {
+  assignRanks,
   getEventConfig,
   listBallots,
   listSubmissions,
   tallyVotes,
   voterCount,
 } from '@/lib/voting';
-import type { Submission } from '@/types/voting';
 
 export const dynamic = 'force-dynamic';
-
-function assignRanks(rows: Array<Submission & { voteCount: number }>): Array<Submission & { voteCount: number; rank: number }> {
-  const sorted = [...rows].sort((a, b) => b.voteCount - a.voteCount);
-  let rank = 0;
-  let lastCount = -1;
-  let seen = 0;
-  return sorted.map((r) => {
-    seen += 1;
-    if (r.voteCount !== lastCount) {
-      rank = seen;
-      lastCount = r.voteCount;
-    }
-    return { ...r, rank };
-  });
-}
 
 export async function GET() {
   const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;

--- a/src/app/api/admin/results/route.ts
+++ b/src/app/api/admin/results/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import {
+  getEventConfig,
+  listBallots,
+  listSubmissions,
+  tallyVotes,
+  voterCount,
+} from '@/lib/voting';
+import type { Submission } from '@/types/voting';
+
+export const dynamic = 'force-dynamic';
+
+function assignRanks(rows: Array<Submission & { voteCount: number }>): Array<Submission & { voteCount: number; rank: number }> {
+  const sorted = [...rows].sort((a, b) => b.voteCount - a.voteCount);
+  let rank = 0;
+  let lastCount = -1;
+  let seen = 0;
+  return sorted.map((r) => {
+    seen += 1;
+    if (r.voteCount !== lastCount) {
+      rank = seen;
+      lastCount = r.voteCount;
+    }
+    return { ...r, rank };
+  });
+}
+
+export async function GET() {
+  const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+  if (!verifySession(session, Date.now())) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+
+  const event = await getEventConfig();
+  const [subs, ballots, totalVoters] = await Promise.all([
+    listSubmissions(event.slug),
+    listBallots(event.slug),
+    voterCount(event.slug),
+  ]);
+  const approvedIds = new Set(subs.filter((s) => s.status === 'approved').map((s) => s.id));
+  const counts = tallyVotes(ballots, approvedIds);
+  const totalVotes = ballots.reduce((n, b) => n + b.submissionIds.length, 0);
+
+  const rows = subs.map((s) => ({ ...s, voteCount: counts.get(s.id) ?? 0 }));
+  const ranked = assignRanks(rows).map((r) => ({
+    id: r.id,
+    title: r.title,
+    speakerName: r.speakerName,
+    handle: r.handle,
+    contact: r.contact,
+    tag: r.tag,
+    status: r.status,
+    voteCount: r.voteCount,
+    rank: r.rank,
+  }));
+
+  return NextResponse.json({ totalVoters, totalVotes, results: ranked });
+}

--- a/src/app/api/admin/session/route.ts
+++ b/src/app/api/admin/session/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import {
+  ADMIN_SESSION_COOKIE,
+  constantTimeTokenMatch,
+  newSessionCookieValue,
+} from '@/lib/admin';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({ token: z.string().min(1) });
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+  if (!constantTimeTokenMatch(parsed.data.token)) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+  const { value, expiresAt } = newSessionCookieValue();
+  cookies().set({
+    name: ADMIN_SESSION_COOKIE,
+    value,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    expires: expiresAt,
+  });
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/admin/submissions/route.ts
+++ b/src/app/api/admin/submissions/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import { ADMIN_SESSION_COOKIE, verifySession } from '@/lib/admin';
+import {
+  getEventConfig,
+  listSubmissions,
+  setSubmissionStatus,
+  getSubmission,
+} from '@/lib/voting';
+import type { SubmissionStatus } from '@/types/voting';
+
+export const dynamic = 'force-dynamic';
+
+function unauthorized() {
+  return NextResponse.json({ ok: false }, { status: 401 });
+}
+
+function requireSession(): boolean {
+  const v = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+  return verifySession(v, Date.now());
+}
+
+export async function GET(req: Request) {
+  if (!requireSession()) return unauthorized();
+  const url = new URL(req.url);
+  const filter = (url.searchParams.get('status') ?? 'all') as SubmissionStatus | 'all';
+  const event = await getEventConfig();
+  const all = await listSubmissions(event.slug);
+  const submissions = filter === 'all' ? all : all.filter((s) => s.status === filter);
+  return NextResponse.json({ submissions });
+}
+
+const patchSchema = z.object({ status: z.enum(['pending', 'approved', 'rejected']) });
+
+export async function PATCH(req: Request) {
+  if (!requireSession()) return unauthorized();
+  const url = new URL(req.url);
+  const id = url.searchParams.get('id');
+  if (!id) return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  const existing = await getSubmission(id);
+  if (!existing) return NextResponse.json({ ok: false, error: 'not-found' }, { status: 404 });
+  const json = await req.json().catch(() => null);
+  const parsed = patchSchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  }
+  await setSubmissionStatus(id, parsed.data.status);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/submissions/route.ts
+++ b/src/app/api/submissions/route.ts
@@ -38,9 +38,6 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
   }
   const { handle, contact } = parsed.data;
-  if (!(handle && handle.length > 0) && !(contact && contact.length > 0)) {
-    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
-  }
 
   const afterIncr = await incrSubmitRate(event.slug, voter);
   if (afterIncr > event.submissionRateLimitPerCookie24h) {

--- a/src/app/api/submissions/route.ts
+++ b/src/app/api/submissions/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import { VOTER_COOKIE } from '@/middleware';
+import {
+  createSubmission,
+  getEventConfig,
+  getSubmitRate,
+  incrSubmitRate,
+  isWithinWindow,
+} from '@/lib/voting';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  speakerName: z.string().trim().min(1),
+  handle: z.string().trim().optional(),
+  contact: z.string().trim().optional(),
+  title: z.string().trim().min(1).max(80),
+  intro: z.string().trim().min(1).max(500),
+  tag: z.string().trim().optional(),
+  consent: z.literal(true),
+});
+
+export async function POST(req: Request) {
+  const voter = cookies().get(VOTER_COOKIE)?.value;
+  if (!voter) {
+    return NextResponse.json({ ok: false, error: 'cookies-required' }, { status: 400 });
+  }
+
+  const event = await getEventConfig();
+  if (!isWithinWindow(event.submissionOpensAt, event.submissionClosesAt, new Date())) {
+    return NextResponse.json({ ok: false, error: 'closed' }, { status: 400 });
+  }
+
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  }
+  const { handle, contact } = parsed.data;
+  if (!(handle && handle.length > 0) && !(contact && contact.length > 0)) {
+    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  }
+
+  const count = await getSubmitRate(event.slug, voter);
+  if (count >= event.submissionRateLimitPerCookie24h) {
+    return NextResponse.json({ ok: false, error: 'rate-limited' }, { status: 429 });
+  }
+
+  const submission = await createSubmission({
+    event: event.slug,
+    speakerName: parsed.data.speakerName,
+    handle,
+    contact,
+    title: parsed.data.title,
+    intro: parsed.data.intro,
+    tag: parsed.data.tag,
+  });
+  await incrSubmitRate(event.slug, voter);
+
+  return NextResponse.json({ ok: true, id: submission.id });
+}

--- a/src/app/api/submissions/route.ts
+++ b/src/app/api/submissions/route.ts
@@ -5,7 +5,6 @@ import { VOTER_COOKIE } from '@/middleware';
 import {
   createSubmission,
   getEventConfig,
-  getSubmitRate,
   incrSubmitRate,
   isWithinWindow,
 } from '@/lib/voting';
@@ -43,8 +42,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
   }
 
-  const count = await getSubmitRate(event.slug, voter);
-  if (count >= event.submissionRateLimitPerCookie24h) {
+  const afterIncr = await incrSubmitRate(event.slug, voter);
+  if (afterIncr > event.submissionRateLimitPerCookie24h) {
     return NextResponse.json({ ok: false, error: 'rate-limited' }, { status: 429 });
   }
 
@@ -57,7 +56,6 @@ export async function POST(req: Request) {
     intro: parsed.data.intro,
     tag: parsed.data.tag,
   });
-  await incrSubmitRate(event.slug, voter);
 
   return NextResponse.json({ ok: true, id: submission.id });
 }

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -5,7 +5,6 @@ import { VOTER_COOKIE } from '@/middleware';
 import {
   getBallot,
   getEventConfig,
-  isWithinWindow,
   listSubmissions,
   sameCanonicalBallot,
   validateBallot,
@@ -23,7 +22,7 @@ export async function POST(req: Request) {
   }
 
   const event = await getEventConfig();
-  if (!isWithinWindow(event.votingOpensAt, event.votingClosesAt, new Date())) {
+  if (Date.now() >= new Date(event.votingClosesAt).getTime()) {
     return NextResponse.json({ ok: false, error: 'closed' }, { status: 400 });
   }
 

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+import { VOTER_COOKIE } from '@/middleware';
+import {
+  getBallot,
+  getEventConfig,
+  isWithinWindow,
+  listSubmissions,
+  sameCanonicalBallot,
+  validateBallot,
+  writeBallot,
+} from '@/lib/voting';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({ submissionIds: z.array(z.string().min(1)) });
+
+export async function POST(req: Request) {
+  const voter = cookies().get(VOTER_COOKIE)?.value;
+  if (!voter) {
+    return NextResponse.json({ ok: false, error: 'cookies-required' }, { status: 400 });
+  }
+
+  const event = await getEventConfig();
+  if (!isWithinWindow(event.votingOpensAt, event.votingClosesAt, new Date())) {
+    return NextResponse.json({ ok: false, error: 'closed' }, { status: 400 });
+  }
+
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  }
+  const requested = parsed.data.submissionIds;
+
+  // Initial validation pass
+  const initial = await listSubmissions(event.slug);
+  const approvedIds = new Set(initial.filter((s) => s.status === 'approved').map((s) => s.id));
+  const first = validateBallot(requested, event.voteLimit, approvedIds);
+  if (!first.ok) {
+    return NextResponse.json({ ok: false, error: first.error }, { status: 400 });
+  }
+
+  // Idempotency / already-voted check
+  const existing = await getBallot(event.slug, voter);
+  if (existing) {
+    if (sameCanonicalBallot(existing.submissionIds, requested)) {
+      return NextResponse.json({ ok: true, recorded: existing.submissionIds.length, alreadyRecorded: true });
+    }
+    return NextResponse.json({ ok: false, error: 'already-voted' }, { status: 409 });
+  }
+
+  // Re-read right before writing — talks may have changed status
+  const fresh = await listSubmissions(event.slug);
+  const freshApproved = new Set(fresh.filter((s) => s.status === 'approved').map((s) => s.id));
+  const final = requested.filter((id) => freshApproved.has(id));
+  if (final.length === 0) {
+    return NextResponse.json({ ok: false, error: 'selection-unavailable' }, { status: 409 });
+  }
+
+  await writeBallot(event.slug, voter, {
+    submissionIds: final,
+    submittedAt: new Date().toISOString(),
+  });
+
+  const dropped = requested.length - final.length;
+  return NextResponse.json({
+    ok: true,
+    recorded: final.length,
+    ...(dropped > 0 ? { dropped } : {}),
+  });
+}

--- a/src/app/submit/SubmissionForm.tsx
+++ b/src/app/submit/SubmissionForm.tsx
@@ -1,16 +1,20 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/Button';
 
 interface Props {
   disabled: boolean;
-  submissionClosesAt: string;
-  eventName: string;
 }
 
 type Status = 'idle' | 'submitting' | 'success' | 'error';
 
-export function SubmissionForm({ disabled, submissionClosesAt, eventName }: Props) {
+const inputClass =
+  'w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-sm placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 disabled:bg-gray-50 disabled:text-gray-500';
+const labelClass = 'mb-1.5 block text-sm font-medium text-gray-900';
+
+export function SubmissionForm({ disabled }: Props) {
   const [status, setStatus] = useState<Status>('idle');
   const [errorMsg, setErrorMsg] = useState<string>('');
 
@@ -25,7 +29,6 @@ export function SubmissionForm({ disabled, submissionClosesAt, eventName }: Prop
       contact: String(fd.get('contact') ?? '').trim() || undefined,
       title: String(fd.get('title') ?? '').trim(),
       intro: String(fd.get('intro') ?? '').trim(),
-      tag: String(fd.get('tag') ?? '').trim() || undefined,
       consent: fd.get('consent') === 'on',
     };
     const res = await fetch('/api/submissions', {
@@ -51,87 +54,96 @@ export function SubmissionForm({ disabled, submissionClosesAt, eventName }: Prop
         break;
       case 'validation':
       default:
-        setErrorMsg('Please fill in every required field, including a handle or contact.');
+        setErrorMsg('Please fill in name, title, intro, and tick the consent box.');
     }
   }
 
   if (status === 'success') {
     return (
-      <div className="rounded-md border border-green-300 bg-green-50 p-4 text-green-900">
-        <p className="font-medium">Thanks — your talk is under review.</p>
-        <p className="text-sm">You&apos;ll see it on the voting page once organizers approve it.</p>
+      <div className="rounded-lg border border-green-200 bg-green-50 p-6 shadow-sm">
+        <p className="text-lg font-semibold text-green-900">Thanks — your talk is under review.</p>
+        <p className="mt-2 text-sm text-green-800">
+          You&apos;ll see it on the voting page once organizers approve it.
+        </p>
+        <div className="mt-5">
+          <Link href="/vote">
+            <Button size="lg">Go vote for other talks →</Button>
+          </Link>
+        </div>
       </div>
     );
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      <p className="text-sm text-neutral-600">
-        Submitting to <strong>{eventName}</strong>. Window closes{' '}
-        {new Date(submissionClosesAt).toLocaleString()}.
-      </p>
+    <form onSubmit={onSubmit} className="space-y-5">
       <label className="block">
-        <span className="mb-1 block text-sm font-medium">Your name</span>
-        <input
-          name="speakerName"
-          required
-          className="w-full rounded border border-neutral-300 p-2"
-          disabled={disabled}
-        />
+        <span className={labelClass}>Name</span>
+        <input name="speakerName" required className={inputClass} disabled={disabled} />
       </label>
       <label className="block">
-        <span className="mb-1 block text-sm font-medium">Public handle (optional if you fill in contact)</span>
-        <input name="handle" className="w-full rounded border border-neutral-300 p-2" disabled={disabled} />
+        <span className={labelClass}>Talk title</span>
+        <input name="title" required maxLength={80} className={inputClass} disabled={disabled} />
+        <span className="mt-1 block text-xs text-gray-500">Up to 80 characters.</span>
       </label>
       <label className="block">
-        <span className="mb-1 block text-sm font-medium">Contact info (optional if you fill in handle)</span>
-        <input name="contact" className="w-full rounded border border-neutral-300 p-2" disabled={disabled} />
-      </label>
-      <label className="block">
-        <span className="mb-1 block text-sm font-medium">Talk title (≤ 80 chars)</span>
-        <input
-          name="title"
-          required
-          maxLength={80}
-          className="w-full rounded border border-neutral-300 p-2"
-          disabled={disabled}
-        />
-      </label>
-      <label className="block">
-        <span className="mb-1 block text-sm font-medium">Short intro (≤ 500 chars)</span>
+        <span className={labelClass}>Short intro</span>
         <textarea
           name="intro"
           required
           maxLength={500}
-          rows={4}
-          className="w-full rounded border border-neutral-300 p-2"
+          rows={5}
+          className={inputClass}
           disabled={disabled}
         />
+        <span className="mt-1 block text-xs text-gray-500">Up to 500 characters.</span>
       </label>
       <label className="block">
-        <span className="mb-1 block text-sm font-medium">Tag (optional)</span>
-        <input name="tag" className="w-full rounded border border-neutral-300 p-2" disabled={disabled} />
+        <span className={labelClass}>GitHub</span>
+        <input name="handle" className={inputClass} disabled={disabled} placeholder="@username" />
+        <span className="mt-1 block text-xs text-gray-500">Optional. Not shown publicly.</span>
       </label>
-      <label className="flex items-start gap-2 text-sm">
-        <input type="checkbox" name="consent" required disabled={disabled} />
+      <label className="block">
+        <span className={labelClass}>Email</span>
+        <input
+          name="contact"
+          type="email"
+          className={inputClass}
+          disabled={disabled}
+          placeholder="you@example.com"
+        />
+        <span className="mt-1 block text-xs text-gray-500">Optional. Not shown publicly.</span>
+      </label>
+      <label className="flex items-start gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+        <input
+          type="checkbox"
+          name="consent"
+          required
+          disabled={disabled}
+          className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-600"
+        />
         <span>
           I understand this is a 5-minute lightning talk and agree my submission can be displayed publicly for
           voting.
         </span>
       </label>
       {status === 'error' && (
-        <p role="alert" className="text-sm text-red-700">
+        <p role="alert" className="text-sm font-medium text-red-700">
           {errorMsg}
         </p>
       )}
-      <button
-        type="submit"
-        disabled={disabled || status === 'submitting'}
-        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
-      >
-        {status === 'submitting' ? 'Submitting…' : 'Submit talk'}
-      </button>
-      {disabled && <p className="text-sm text-neutral-600">Submissions are closed.</p>}
+      <div className="pt-2">
+        <Button
+          type="submit"
+          size="lg"
+          disabled={disabled || status === 'submitting'}
+          className="w-full sm:w-auto"
+        >
+          {status === 'submitting' ? 'Submitting…' : 'Submit talk'}
+        </Button>
+      </div>
+      {disabled && (
+        <p className="text-sm text-gray-600">Submissions are closed.</p>
+      )}
     </form>
   );
 }

--- a/src/app/submit/SubmissionForm.tsx
+++ b/src/app/submit/SubmissionForm.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  disabled: boolean;
+  submissionClosesAt: string;
+  eventName: string;
+}
+
+type Status = 'idle' | 'submitting' | 'success' | 'error';
+
+export function SubmissionForm({ disabled, submissionClosesAt, eventName }: Props) {
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (disabled) return;
+    setStatus('submitting');
+    const fd = new FormData(e.currentTarget);
+    const body = {
+      speakerName: String(fd.get('speakerName') ?? '').trim(),
+      handle: String(fd.get('handle') ?? '').trim() || undefined,
+      contact: String(fd.get('contact') ?? '').trim() || undefined,
+      title: String(fd.get('title') ?? '').trim(),
+      intro: String(fd.get('intro') ?? '').trim(),
+      tag: String(fd.get('tag') ?? '').trim() || undefined,
+      consent: fd.get('consent') === 'on',
+    };
+    const res = await fetch('/api/submissions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.ok) {
+      setStatus('success');
+      return;
+    }
+    setStatus('error');
+    switch (data.error) {
+      case 'closed':
+        setErrorMsg('Submissions are closed.');
+        break;
+      case 'rate-limited':
+        setErrorMsg("You've reached the limit of submissions from this browser in 24 hours.");
+        break;
+      case 'cookies-required':
+        setErrorMsg('Please enable cookies and reload before submitting.');
+        break;
+      case 'validation':
+      default:
+        setErrorMsg('Please fill in every required field, including a handle or contact.');
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="rounded-md border border-green-300 bg-green-50 p-4 text-green-900">
+        <p className="font-medium">Thanks — your talk is under review.</p>
+        <p className="text-sm">You&apos;ll see it on the voting page once organizers approve it.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <p className="text-sm text-neutral-600">
+        Submitting to <strong>{eventName}</strong>. Window closes{' '}
+        {new Date(submissionClosesAt).toLocaleString()}.
+      </p>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Your name</span>
+        <input
+          name="speakerName"
+          required
+          className="w-full rounded border border-neutral-300 p-2"
+          disabled={disabled}
+        />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Public handle (optional if you fill in contact)</span>
+        <input name="handle" className="w-full rounded border border-neutral-300 p-2" disabled={disabled} />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Contact info (optional if you fill in handle)</span>
+        <input name="contact" className="w-full rounded border border-neutral-300 p-2" disabled={disabled} />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Talk title (≤ 80 chars)</span>
+        <input
+          name="title"
+          required
+          maxLength={80}
+          className="w-full rounded border border-neutral-300 p-2"
+          disabled={disabled}
+        />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Short intro (≤ 500 chars)</span>
+        <textarea
+          name="intro"
+          required
+          maxLength={500}
+          rows={4}
+          className="w-full rounded border border-neutral-300 p-2"
+          disabled={disabled}
+        />
+      </label>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Tag (optional)</span>
+        <input name="tag" className="w-full rounded border border-neutral-300 p-2" disabled={disabled} />
+      </label>
+      <label className="flex items-start gap-2 text-sm">
+        <input type="checkbox" name="consent" required disabled={disabled} />
+        <span>
+          I understand this is a 5-minute lightning talk and agree my submission can be displayed publicly for
+          voting.
+        </span>
+      </label>
+      {status === 'error' && (
+        <p role="alert" className="text-sm text-red-700">
+          {errorMsg}
+        </p>
+      )}
+      <button
+        type="submit"
+        disabled={disabled || status === 'submitting'}
+        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+      >
+        {status === 'submitting' ? 'Submitting…' : 'Submit talk'}
+      </button>
+      {disabled && <p className="text-sm text-neutral-600">Submissions are closed.</p>}
+    </form>
+  );
+}

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -1,4 +1,5 @@
 import { getEventConfig, isWithinWindow } from '@/lib/voting';
+import { Container } from '@/components/ui/Container';
 import { SubmissionForm } from './SubmissionForm';
 
 export const dynamic = 'force-dynamic';
@@ -7,16 +8,17 @@ export default async function SubmitPage() {
   const event = await getEventConfig();
   const open = isWithinWindow(event.submissionOpensAt, event.submissionClosesAt, new Date());
   return (
-    <div className="mx-auto max-w-lg px-4 py-10">
-      <h1 className="mb-2 text-2xl font-semibold">Submit a 5-minute talk</h1>
-      <p className="mb-6 text-sm text-neutral-600">
-        Share something useful, fun, or inspiring with the community.
-      </p>
-      <SubmissionForm
-        disabled={!open}
-        submissionClosesAt={event.submissionClosesAt}
-        eventName={event.name}
-      />
-    </div>
+    <section className="py-16 sm:py-20">
+      <Container>
+        <div className="mx-auto max-w-xl">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            Submit a lightning talk
+          </h1>
+          <div className="mt-10">
+            <SubmissionForm disabled={!open} />
+          </div>
+        </div>
+      </Container>
+    </section>
   );
 }

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -1,0 +1,22 @@
+import { getEventConfig, isWithinWindow } from '@/lib/voting';
+import { SubmissionForm } from './SubmissionForm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SubmitPage() {
+  const event = await getEventConfig();
+  const open = isWithinWindow(event.submissionOpensAt, event.submissionClosesAt, new Date());
+  return (
+    <div className="mx-auto max-w-lg px-4 py-10">
+      <h1 className="mb-2 text-2xl font-semibold">Submit a 5-minute talk</h1>
+      <p className="mb-6 text-sm text-neutral-600">
+        Share something useful, fun, or inspiring with the community.
+      </p>
+      <SubmissionForm
+        disabled={!open}
+        submissionClosesAt={event.submissionClosesAt}
+        eventName={event.name}
+      />
+    </div>
+  );
+}

--- a/src/app/vote/VoteClient.tsx
+++ b/src/app/vote/VoteClient.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Card {
+  id: string;
+  title: string;
+  speakerName: string;
+  handle?: string;
+  tag?: string;
+  intro: string;
+}
+
+export function VoteClient({ cards, voteLimit }: { cards: Card[]; voteLimit: number }) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState<string>('');
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else if (next.size < voteLimit) next.add(id);
+      return next;
+    });
+  }
+
+  async function submit() {
+    setStatus('submitting');
+    const res = await fetch('/api/votes', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ submissionIds: Array.from(selected) }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.ok) {
+      setStatus('success');
+      const dropped = Number(data.dropped ?? 0);
+      setMessage(
+        dropped > 0
+          ? 'Vote recorded, but some selections were no longer available.'
+          : data.alreadyRecorded
+            ? 'You already submitted this ballot. Nothing changed.'
+            : 'Thanks — your vote has been recorded.'
+      );
+      return;
+    }
+    setStatus('error');
+    switch (data.error) {
+      case 'already-voted':
+        setMessage('This browser has already submitted a ballot.');
+        break;
+      case 'selection-unavailable':
+        setMessage('Your selected talks changed while you were voting. Refresh and try again.');
+        break;
+      case 'closed':
+        setMessage('Voting is closed.');
+        break;
+      case 'cookies-required':
+        setMessage('Please enable cookies and reload.');
+        break;
+      case 'unknown-submission':
+        setMessage('One of your selections is no longer available. Refresh and try again.');
+        break;
+      default:
+        setMessage('Could not record your vote. Try again.');
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="rounded-md border border-green-300 bg-green-50 p-4 text-green-900">
+        <p className="font-medium">{message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-neutral-600">
+        Pick up to {voteLimit} talks. {selected.size}/{voteLimit} selected.
+      </p>
+      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {cards.map((c) => {
+          const isSelected = selected.has(c.id);
+          return (
+            <li key={c.id}>
+              <button
+                type="button"
+                onClick={() => toggle(c.id)}
+                className={`w-full rounded-lg border p-4 text-left transition ${
+                  isSelected ? 'border-black bg-neutral-900 text-white' : 'border-neutral-300 bg-white'
+                }`}
+                aria-pressed={isSelected}
+              >
+                <div className="font-medium">{c.title}</div>
+                <div className="text-xs opacity-80">
+                  {c.speakerName}
+                  {c.handle ? ` · ${c.handle}` : ''}
+                  {c.tag ? ` · ${c.tag}` : ''}
+                </div>
+                <p className="mt-2 text-sm opacity-90">{c.intro}</p>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {status === 'error' && (
+        <p role="alert" className="text-sm text-red-700">
+          {message}
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={submit}
+        disabled={selected.size === 0 || status === 'submitting'}
+        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+      >
+        {status === 'submitting' ? 'Submitting…' : `Submit vote (${selected.size})`}
+      </button>
+    </div>
+  );
+}

--- a/src/app/vote/VoteClient.tsx
+++ b/src/app/vote/VoteClient.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
 
 interface Card {
   id: string;
   title: string;
   speakerName: string;
-  handle?: string;
-  tag?: string;
   intro: string;
 }
 
@@ -15,6 +14,8 @@ export function VoteClient({ cards, voteLimit }: { cards: Card[]; voteLimit: num
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState<string>('');
+
+  const atLimit = selected.size >= voteLimit;
 
   function toggle(id: string) {
     setSelected((prev) => {
@@ -69,55 +70,69 @@ export function VoteClient({ cards, voteLimit }: { cards: Card[]; voteLimit: num
 
   if (status === 'success') {
     return (
-      <div className="rounded-md border border-green-300 bg-green-50 p-4 text-green-900">
-        <p className="font-medium">{message}</p>
+      <div className="rounded-lg border border-green-200 bg-green-50 p-6 shadow-sm">
+        <p className="text-lg font-semibold text-green-900">{message}</p>
       </div>
     );
   }
 
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-neutral-600">
-        Pick up to {voteLimit} talks. {selected.size}/{voteLimit} selected.
+    <div className="space-y-6">
+      <p className="text-sm text-gray-600">
+        Pick up to {voteLimit} talks. <span className="font-medium text-gray-900">{selected.size}/{voteLimit}</span> selected.
       </p>
-      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {cards.map((c) => {
           const isSelected = selected.has(c.id);
+          const disabled = !isSelected && atLimit;
           return (
             <li key={c.id}>
               <button
                 type="button"
                 onClick={() => toggle(c.id)}
-                className={`w-full rounded-lg border p-4 text-left transition ${
-                  isSelected ? 'border-black bg-neutral-900 text-white' : 'border-neutral-300 bg-white'
-                }`}
+                disabled={disabled}
                 aria-pressed={isSelected}
+                className={`group relative flex h-full w-full flex-col rounded-lg border p-5 text-left shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+                  isSelected
+                    ? 'border-blue-600 bg-blue-50 ring-2 ring-blue-600'
+                    : 'border-gray-200 bg-white hover:border-gray-300 hover:shadow-md'
+                }`}
               >
-                <div className="font-medium">{c.title}</div>
-                <div className="text-xs opacity-80">
+                {isSelected && (
+                  <span className="absolute right-4 top-4 flex h-6 w-6 items-center justify-center rounded-full bg-blue-600 text-xs font-semibold text-white">
+                    ✓
+                  </span>
+                )}
+                <h3 className="pr-8 text-lg font-semibold text-gray-900">{c.title}</h3>
+                <p className="mt-1 text-xs font-medium uppercase tracking-wide text-gray-500">
                   {c.speakerName}
-                  {c.handle ? ` · ${c.handle}` : ''}
-                  {c.tag ? ` · ${c.tag}` : ''}
-                </div>
-                <p className="mt-2 text-sm opacity-90">{c.intro}</p>
+                </p>
+                <p className="mt-3 text-sm leading-6 text-gray-600">{c.intro}</p>
               </button>
             </li>
           );
         })}
       </ul>
       {status === 'error' && (
-        <p role="alert" className="text-sm text-red-700">
+        <p role="alert" className="text-sm font-medium text-red-700">
           {message}
         </p>
       )}
-      <button
-        type="button"
-        onClick={submit}
-        disabled={selected.size === 0 || status === 'submitting'}
-        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
-      >
-        {status === 'submitting' ? 'Submitting…' : `Submit vote (${selected.size})`}
-      </button>
+      <div className="flex flex-col gap-3 border-t border-gray-200 pt-6 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-gray-600">
+          {selected.size === 0
+            ? 'Select at least one talk to submit your vote.'
+            : `You're voting for ${selected.size} ${selected.size === 1 ? 'talk' : 'talks'}.`}
+        </p>
+        <Button
+          type="button"
+          size="lg"
+          onClick={submit}
+          disabled={selected.size === 0 || status === 'submitting'}
+        >
+          {status === 'submitting' ? 'Submitting…' : `Submit vote${selected.size > 0 ? ` (${selected.size})` : ''}`}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/app/vote/page.tsx
+++ b/src/app/vote/page.tsx
@@ -3,17 +3,17 @@ import { VOTER_COOKIE } from '@/middleware';
 import {
   getBallot,
   getEventConfig,
-  isWithinWindow,
   listSubmissions,
   shuffleWithSeed,
 } from '@/lib/voting';
+import { Container } from '@/components/ui/Container';
 import { VoteClient } from './VoteClient';
 
 export const dynamic = 'force-dynamic';
 
 export default async function VotePage() {
   const event = await getEventConfig();
-  const open = isWithinWindow(event.votingOpensAt, event.votingClosesAt, new Date());
+  const closed = Date.now() >= new Date(event.votingClosesAt).getTime();
   const voter = cookies().get(VOTER_COOKIE)?.value;
   const seed = (voter ?? `anon-${Date.now()}`) + ':' + event.slug;
   const [all, existing] = await Promise.all([
@@ -26,41 +26,43 @@ export default async function VotePage() {
       id: s.id,
       title: s.title,
       speakerName: s.speakerName,
-      handle: s.handle,
-      tag: s.tag,
       intro: s.intro,
     })),
     seed
   );
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-10">
-      <h1 className="mb-2 text-2xl font-semibold">Vote for talks you want to hear</h1>
-      <p className="mb-6 text-sm text-neutral-600">
-        {event.name} · voting closes {new Date(event.votingClosesAt).toLocaleString()}
-      </p>
+    <section className="py-16 sm:py-20">
+      <Container>
+        <div className="mx-auto max-w-3xl">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            Vote for talks you want to hear
+          </h1>
 
-      {existing ? (
-        <div className="rounded-md border border-neutral-300 bg-neutral-50 p-4">
-          <p className="font-medium">You&apos;ve already voted from this browser.</p>
-          <p className="text-sm text-neutral-700">
-            {existing.submissionIds.length} selection(s) recorded at{' '}
-            {new Date(existing.submittedAt).toLocaleString()}.
-          </p>
+          <div className="mt-10">
+            {existing ? (
+              <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+                <p className="text-lg font-semibold text-gray-900">
+                  You&apos;ve already voted from this browser.
+                </p>
+                <p className="mt-2 text-sm text-gray-600">
+                  {existing.submissionIds.length} selection(s) recorded at{' '}
+                  {new Date(existing.submittedAt).toLocaleString()}.
+                </p>
+              </div>
+            ) : closed ? (
+              <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+                <p className="text-lg font-semibold text-gray-900">Voting is closed.</p>
+                <p className="mt-2 text-sm text-gray-600">Results will be announced soon.</p>
+              </div>
+            ) : approved.length === 0 ? (
+              <p className="text-gray-600">No talks are available for voting yet.</p>
+            ) : (
+              <VoteClient cards={cards} voteLimit={event.voteLimit} />
+            )}
+          </div>
         </div>
-      ) : !open ? (
-        <div className="rounded-md border border-neutral-300 bg-neutral-50 p-4">
-          <p className="font-medium">
-            {Date.now() < new Date(event.votingOpensAt).getTime()
-              ? `Voting opens ${new Date(event.votingOpensAt).toLocaleString()}.`
-              : 'Voting is closed. Results will be announced soon.'}
-          </p>
-        </div>
-      ) : approved.length === 0 ? (
-        <p className="text-sm text-neutral-700">No talks are available for voting yet.</p>
-      ) : (
-        <VoteClient cards={cards} voteLimit={event.voteLimit} />
-      )}
-    </div>
+      </Container>
+    </section>
   );
 }

--- a/src/app/vote/page.tsx
+++ b/src/app/vote/page.tsx
@@ -1,0 +1,66 @@
+import { cookies } from 'next/headers';
+import { VOTER_COOKIE } from '@/middleware';
+import {
+  getBallot,
+  getEventConfig,
+  isWithinWindow,
+  listSubmissions,
+  shuffleWithSeed,
+} from '@/lib/voting';
+import { VoteClient } from './VoteClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function VotePage() {
+  const event = await getEventConfig();
+  const open = isWithinWindow(event.votingOpensAt, event.votingClosesAt, new Date());
+  const voter = cookies().get(VOTER_COOKIE)?.value;
+  const seed = (voter ?? `anon-${Date.now()}`) + ':' + event.slug;
+  const [all, existing] = await Promise.all([
+    listSubmissions(event.slug),
+    voter ? getBallot(event.slug, voter) : Promise.resolve(null),
+  ]);
+  const approved = all.filter((s) => s.status === 'approved');
+  const cards = shuffleWithSeed(
+    approved.map((s) => ({
+      id: s.id,
+      title: s.title,
+      speakerName: s.speakerName,
+      handle: s.handle,
+      tag: s.tag,
+      intro: s.intro,
+    })),
+    seed
+  );
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10">
+      <h1 className="mb-2 text-2xl font-semibold">Vote for talks you want to hear</h1>
+      <p className="mb-6 text-sm text-neutral-600">
+        {event.name} · voting closes {new Date(event.votingClosesAt).toLocaleString()}
+      </p>
+
+      {existing ? (
+        <div className="rounded-md border border-neutral-300 bg-neutral-50 p-4">
+          <p className="font-medium">You&apos;ve already voted from this browser.</p>
+          <p className="text-sm text-neutral-700">
+            {existing.submissionIds.length} selection(s) recorded at{' '}
+            {new Date(existing.submittedAt).toLocaleString()}.
+          </p>
+        </div>
+      ) : !open ? (
+        <div className="rounded-md border border-neutral-300 bg-neutral-50 p-4">
+          <p className="font-medium">
+            {Date.now() < new Date(event.votingOpensAt).getTime()
+              ? `Voting opens ${new Date(event.votingOpensAt).toLocaleString()}.`
+              : 'Voting is closed. Results will be announced soon.'}
+          </p>
+        </div>
+      ) : approved.length === 0 ? (
+        <p className="text-sm text-neutral-700">No talks are available for voting yet.</p>
+      ) : (
+        <VoteClient cards={cards} voteLimit={event.voteLimit} />
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/admin.test.ts
+++ b/src/lib/__tests__/admin.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const SECRET = 'a'.repeat(48);
+
+beforeEach(() => {
+  process.env.ADMIN_TOKEN = SECRET;
+});
+
+async function load() {
+  return await import('@/lib/admin');
+}
+
+describe('constantTimeTokenMatch', () => {
+  it('matches the configured token', async () => {
+    const { constantTimeTokenMatch } = await load();
+    expect(constantTimeTokenMatch(SECRET)).toBe(true);
+  });
+  it('rejects a different same-length token', async () => {
+    const { constantTimeTokenMatch } = await load();
+    expect(constantTimeTokenMatch('b'.repeat(48))).toBe(false);
+  });
+  it('rejects a shorter token', async () => {
+    const { constantTimeTokenMatch } = await load();
+    expect(constantTimeTokenMatch('short')).toBe(false);
+  });
+  it('rejects when ADMIN_TOKEN is unset', async () => {
+    delete process.env.ADMIN_TOKEN;
+    const { constantTimeTokenMatch } = await load();
+    expect(constantTimeTokenMatch(SECRET)).toBe(false);
+  });
+});
+
+describe('signSession / verifySession', () => {
+  it('verifies a freshly signed session', async () => {
+    const { signSession, verifySession } = await load();
+    const now = 1_700_000_000_000;
+    const exp = now + 60_000;
+    const value = signSession(exp);
+    expect(verifySession(value, now)).toBe(true);
+  });
+  it('rejects an expired session', async () => {
+    const { signSession, verifySession } = await load();
+    const now = 1_700_000_000_000;
+    const exp = now - 1;
+    expect(verifySession(signSession(exp), now)).toBe(false);
+  });
+  it('rejects a tampered signature', async () => {
+    const { signSession, verifySession } = await load();
+    const now = 1_700_000_000_000;
+    const value = signSession(now + 60_000);
+    const tampered = value.slice(0, -1) + (value.slice(-1) === 'a' ? 'b' : 'a');
+    expect(verifySession(tampered, now)).toBe(false);
+  });
+  it('rejects a malformed value', async () => {
+    const { verifySession } = await load();
+    expect(verifySession('not-a-session', Date.now())).toBe(false);
+    expect(verifySession(undefined, Date.now())).toBe(false);
+  });
+});
+
+describe('newSessionCookieValue', () => {
+  it('produces a value that verifies right now', async () => {
+    const { newSessionCookieValue, verifySession } = await load();
+    const now = Date.now();
+    const { value, expiresAt } = newSessionCookieValue(now);
+    expect(verifySession(value, now)).toBe(true);
+    expect(expiresAt.getTime()).toBeGreaterThan(now);
+  });
+});

--- a/src/lib/__tests__/voting.test.ts
+++ b/src/lib/__tests__/voting.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isWithinWindow,
+  validateBallot,
+  sameCanonicalBallot,
+  tallyVotes,
+  shuffleWithSeed,
+} from '@/lib/voting';
+
+describe('isWithinWindow', () => {
+  const opens = '2026-04-20T00:00:00Z';
+  const closes = '2026-04-27T00:00:00Z';
+
+  it('is false before opens', () => {
+    expect(isWithinWindow(opens, closes, new Date('2026-04-19T23:59:59Z'))).toBe(false);
+  });
+  it('is true at opens', () => {
+    expect(isWithinWindow(opens, closes, new Date('2026-04-20T00:00:00Z'))).toBe(true);
+  });
+  it('is true mid-window', () => {
+    expect(isWithinWindow(opens, closes, new Date('2026-04-23T12:00:00Z'))).toBe(true);
+  });
+  it('is false at closes (exclusive)', () => {
+    expect(isWithinWindow(opens, closes, new Date('2026-04-27T00:00:00Z'))).toBe(false);
+  });
+});
+
+describe('validateBallot', () => {
+  const approved = new Set(['a', 'b', 'c', 'd']);
+
+  it('rejects empty array', () => {
+    expect(validateBallot([], 3, approved)).toEqual({ ok: false, error: 'validation' });
+  });
+  it('rejects over limit', () => {
+    expect(validateBallot(['a', 'b', 'c', 'd'], 3, approved)).toEqual({ ok: false, error: 'validation' });
+  });
+  it('rejects duplicates', () => {
+    expect(validateBallot(['a', 'a'], 3, approved)).toEqual({ ok: false, error: 'validation' });
+  });
+  it('rejects unknown id', () => {
+    expect(validateBallot(['a', 'z'], 3, approved)).toEqual({ ok: false, error: 'unknown-submission' });
+  });
+  it('accepts a valid ballot', () => {
+    expect(validateBallot(['a', 'b'], 3, approved)).toEqual({ ok: true });
+  });
+});
+
+describe('sameCanonicalBallot', () => {
+  it('is true for same ids in same order', () => {
+    expect(sameCanonicalBallot(['a', 'b'], ['a', 'b'])).toBe(true);
+  });
+  it('is true for same ids different order', () => {
+    expect(sameCanonicalBallot(['a', 'b', 'c'], ['c', 'a', 'b'])).toBe(true);
+  });
+  it('is false for different lengths', () => {
+    expect(sameCanonicalBallot(['a'], ['a', 'b'])).toBe(false);
+  });
+  it('is false for different ids', () => {
+    expect(sameCanonicalBallot(['a', 'b'], ['a', 'c'])).toBe(false);
+  });
+});
+
+describe('tallyVotes', () => {
+  const approved = new Set(['a', 'b', 'c']);
+
+  it('counts approved ids only', () => {
+    const ballots = [
+      { submissionIds: ['a', 'b'] },
+      { submissionIds: ['a', 'c'] },
+      { submissionIds: ['a', 'd'] }, // d is not approved -> ignored
+    ];
+    const counts = tallyVotes(ballots, approved);
+    expect(counts.get('a')).toBe(3);
+    expect(counts.get('b')).toBe(1);
+    expect(counts.get('c')).toBe(1);
+    expect(counts.has('d')).toBe(false);
+  });
+
+  it('returns an empty map when no ballots', () => {
+    expect(tallyVotes([], approved).size).toBe(0);
+  });
+});
+
+describe('shuffleWithSeed', () => {
+  it('is deterministic for the same seed', () => {
+    const a = shuffleWithSeed(['x', 'y', 'z', 'w', 'v'], 'seed-1');
+    const b = shuffleWithSeed(['x', 'y', 'z', 'w', 'v'], 'seed-1');
+    expect(a).toEqual(b);
+  });
+  it('differs across seeds', () => {
+    const a = shuffleWithSeed(['x', 'y', 'z', 'w', 'v'], 'seed-1');
+    const b = shuffleWithSeed(['x', 'y', 'z', 'w', 'v'], 'seed-2');
+    expect(a).not.toEqual(b);
+  });
+  it('preserves the multiset', () => {
+    const input = ['x', 'y', 'z', 'w', 'v'];
+    const out = shuffleWithSeed(input, 'seed-3');
+    expect(out.sort()).toEqual([...input].sort());
+  });
+  it('does not mutate input', () => {
+    const input = ['x', 'y', 'z'];
+    shuffleWithSeed(input, 's');
+    expect(input).toEqual(['x', 'y', 'z']);
+  });
+});

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -9,12 +9,12 @@ function secret(): string {
 
 export function constantTimeTokenMatch(provided: string): boolean {
   const expected = secret();
-  if (!expected) return false;
   const a = Buffer.from(provided);
   const b = Buffer.from(expected);
-  if (a.length !== b.length) {
-    // keep timing stable even when lengths differ
-    crypto.timingSafeEqual(Buffer.alloc(b.length), b);
+  if (!expected || a.length !== b.length) {
+    // Always run timingSafeEqual so timing is stable across "unset", "wrong length", and "wrong value" paths
+    const dummy = Buffer.alloc(Math.max(a.length, 1));
+    crypto.timingSafeEqual(dummy, Buffer.alloc(dummy.length));
     return false;
   }
   return crypto.timingSafeEqual(a, b);

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,52 @@
+import crypto from 'crypto';
+
+const SESSION_TTL_MS = 8 * 60 * 60 * 1000;
+export const ADMIN_SESSION_COOKIE = 'zts_admin';
+
+function secret(): string {
+  return process.env.ADMIN_TOKEN ?? '';
+}
+
+export function constantTimeTokenMatch(provided: string): boolean {
+  const expected = secret();
+  if (!expected) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    // keep timing stable even when lengths differ
+    crypto.timingSafeEqual(Buffer.alloc(b.length), b);
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+}
+
+export function signSession(expMs: number): string {
+  const payload = String(expMs);
+  const hmac = crypto.createHmac('sha256', secret()).update(payload).digest('base64url');
+  return `${payload}.${hmac}`;
+}
+
+export function verifySession(value: string | undefined, nowMs: number): boolean {
+  if (!value) return false;
+  const dot = value.indexOf('.');
+  if (dot <= 0) return false;
+  const payload = value.slice(0, dot);
+  const sig = value.slice(dot + 1);
+  const expMs = Number(payload);
+  if (!Number.isFinite(expMs) || expMs < nowMs) return false;
+  const expected = crypto.createHmac('sha256', secret()).update(payload).digest('base64url');
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+export interface NewSession {
+  value: string;
+  expiresAt: Date;
+}
+
+export function newSessionCookieValue(nowMs: number = Date.now()): NewSession {
+  const expMs = nowMs + SESSION_TTL_MS;
+  return { value: signSession(expMs), expiresAt: new Date(expMs) };
+}

--- a/src/lib/voting.ts
+++ b/src/lib/voting.ts
@@ -84,3 +84,73 @@ export function shuffleWithSeed<T>(items: T[], seed: string): T[] {
   }
   return arr;
 }
+
+import { kv } from '@vercel/kv';
+import type { Submission, SubmissionStatus, Ballot } from '@/types/voting';
+
+const submissionKey = (id: string) => `submission:${id}`;
+const submissionsSetKey = (event: string) => `submissions:set:${event}`;
+const voteKey = (event: string, voter: string) => `vote:${event}:${voter}`;
+const votersSetKey = (event: string) => `voters:set:${event}`;
+const submitRateKey = (event: string, cookie: string) => `submit-rate:${event}:${cookie}`;
+
+export async function createSubmission(input: Omit<Submission, 'id' | 'status' | 'createdAt'>): Promise<Submission> {
+  const id = crypto.randomUUID();
+  const submission: Submission = {
+    ...input,
+    id,
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+  };
+  await kv.set(submissionKey(id), submission);
+  await kv.sadd(submissionsSetKey(input.event), id);
+  return submission;
+}
+
+export async function getSubmission(id: string): Promise<Submission | null> {
+  return (await kv.get<Submission>(submissionKey(id))) ?? null;
+}
+
+export async function listSubmissions(event: string): Promise<Submission[]> {
+  const ids = (await kv.smembers(submissionsSetKey(event))) as string[];
+  if (ids.length === 0) return [];
+  const results = await Promise.all(ids.map((id) => kv.get<Submission>(submissionKey(id))));
+  return results.filter((s): s is Submission => s !== null);
+}
+
+export async function setSubmissionStatus(id: string, status: SubmissionStatus): Promise<void> {
+  const current = await getSubmission(id);
+  if (!current) throw new Error(`submission ${id} not found`);
+  await kv.set(submissionKey(id), { ...current, status });
+}
+
+export async function getBallot(event: string, voter: string): Promise<Ballot | null> {
+  return (await kv.get<Ballot>(voteKey(event, voter))) ?? null;
+}
+
+export async function writeBallot(event: string, voter: string, ballot: Ballot): Promise<void> {
+  await kv.set(voteKey(event, voter), ballot);
+  await kv.sadd(votersSetKey(event), voter);
+}
+
+export async function voterCount(event: string): Promise<number> {
+  return (await kv.scard(votersSetKey(event))) as number;
+}
+
+export async function listBallots(event: string): Promise<Ballot[]> {
+  const voters = (await kv.smembers(votersSetKey(event))) as string[];
+  if (voters.length === 0) return [];
+  const results = await Promise.all(voters.map((v) => kv.get<Ballot>(voteKey(event, v))));
+  return results.filter((b): b is Ballot => b !== null);
+}
+
+export async function getSubmitRate(event: string, cookie: string): Promise<number> {
+  return (await kv.get<number>(submitRateKey(event, cookie))) ?? 0;
+}
+
+export async function incrSubmitRate(event: string, cookie: string): Promise<number> {
+  const key = submitRateKey(event, cookie);
+  const n = (await kv.incr(key)) as number;
+  if (n === 1) await kv.expire(key, 86400);
+  return n;
+}

--- a/src/lib/voting.ts
+++ b/src/lib/voting.ts
@@ -1,0 +1,86 @@
+import fs from 'fs/promises';
+import path from 'path';
+import type { EventConfig } from '@/types/event';
+
+export async function getEventConfig(slug = 'lightning-talk'): Promise<EventConfig> {
+  const file = path.join(process.cwd(), 'content', 'events', `${slug}.json`);
+  const raw = await fs.readFile(file, 'utf-8');
+  return JSON.parse(raw) as EventConfig;
+}
+
+export function isWithinWindow(opens: string, closes: string, now: Date): boolean {
+  const o = new Date(opens).getTime();
+  const c = new Date(closes).getTime();
+  const n = now.getTime();
+  return n >= o && n < c;
+}
+
+export type BallotValidation =
+  | { ok: true }
+  | { ok: false; error: 'validation' | 'unknown-submission' };
+
+export function validateBallot(
+  submissionIds: unknown,
+  voteLimit: number,
+  approvedIds: Set<string>
+): BallotValidation {
+  if (!Array.isArray(submissionIds)) return { ok: false, error: 'validation' };
+  if (submissionIds.length < 1 || submissionIds.length > voteLimit) {
+    return { ok: false, error: 'validation' };
+  }
+  const seen = new Set<string>();
+  for (const id of submissionIds) {
+    if (typeof id !== 'string' || id.length === 0) return { ok: false, error: 'validation' };
+    if (seen.has(id)) return { ok: false, error: 'validation' };
+    seen.add(id);
+  }
+  for (const id of submissionIds as string[]) {
+    if (!approvedIds.has(id)) return { ok: false, error: 'unknown-submission' };
+  }
+  return { ok: true };
+}
+
+export function sameCanonicalBallot(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const A = [...a].sort();
+  const B = [...b].sort();
+  for (let i = 0; i < A.length; i++) if (A[i] !== B[i]) return false;
+  return true;
+}
+
+export function tallyVotes(
+  ballots: Array<{ submissionIds: string[] }>,
+  approvedIds: Set<string>
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const b of ballots) {
+    for (const id of b.submissionIds) {
+      if (approvedIds.has(id)) counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+function xmur3(str: string): () => number {
+  let h = 1779033703 ^ str.length;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return () => {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    h ^= h >>> 16;
+    return (h >>> 0) / 4294967296;
+  };
+}
+
+export function shuffleWithSeed<T>(items: T[], seed: string): T[] {
+  const rand = xmur3(seed);
+  const arr = [...items];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}

--- a/src/lib/voting.ts
+++ b/src/lib/voting.ts
@@ -61,6 +61,23 @@ export function tallyVotes(
   return counts;
 }
 
+export function assignRanks<T extends { voteCount: number }>(
+  rows: T[]
+): Array<T & { rank: number }> {
+  const sorted = [...rows].sort((a, b) => b.voteCount - a.voteCount);
+  let rank = 0;
+  let lastCount = -1;
+  let seen = 0;
+  return sorted.map((r) => {
+    seen += 1;
+    if (r.voteCount !== lastCount) {
+      rank = seen;
+      lastCount = r.voteCount;
+    }
+    return { ...r, rank };
+  });
+}
+
 function xmur3(str: string): () => number {
   let h = 1779033703 ^ str.length;
   for (let i = 0; i < str.length; i++) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export const VOTER_COOKIE = 'zts_voter';
+
+export function middleware(req: NextRequest) {
+  const res = NextResponse.next();
+  if (!req.cookies.get(VOTER_COOKIE)) {
+    res.cookies.set({
+      name: VOTER_COOKIE,
+      value: crypto.randomUUID(),
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 365,
+    });
+  }
+  return res;
+}
+
+export const config = {
+  matcher: ['/submit', '/vote', '/api/submissions', '/api/votes'],
+};

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -5,7 +5,6 @@ export interface EventConfig {
   name: string;
   submissionOpensAt: string;
   submissionClosesAt: string;
-  votingOpensAt: string;
   votingClosesAt: string;
   voteLimit: number;
   submissionRateLimitPerCookie24h: number;

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,0 +1,13 @@
+export type ContactRule = 'handle-or-contact';
+
+export interface EventConfig {
+  slug: string;
+  name: string;
+  submissionOpensAt: string;
+  submissionClosesAt: string;
+  votingOpensAt: string;
+  votingClosesAt: string;
+  voteLimit: number;
+  submissionRateLimitPerCookie24h: number;
+  contactRule: ContactRule;
+}

--- a/src/types/voting.ts
+++ b/src/types/voting.ts
@@ -1,0 +1,23 @@
+export type SubmissionStatus = 'pending' | 'approved' | 'rejected';
+
+export interface Submission {
+  id: string;
+  event: string;
+  speakerName: string;
+  handle?: string;
+  contact?: string;
+  title: string;
+  intro: string;
+  tag?: string;
+  status: SubmissionStatus;
+  createdAt: string;
+}
+
+export interface Ballot {
+  submissionIds: string[];
+  submittedAt: string;
+}
+
+export interface AdminSession {
+  expMs: number;
+}


### PR DESCRIPTION
## Summary

- New community lightning-talk submission + voting feature under `/submit`, `/vote`, `/admin`.
- Single-event config at `content/events/lightning-talk.json`; mutable data in Vercel KV via `@vercel/kv`.
- Anonymous voter identity via `httpOnly zts_voter` cookie seeded in middleware.
- Admin access via HMAC-signed session cookie (`ADMIN_TOKEN` is both login secret and signing key).
- Ballot semantics: write-once per voter, idempotent-retry on same ballot, `409 already-voted` on different ballot, partial-drop / `selection-unavailable` on post-hoc rejection.
- Unit tests: 92 passing (pure helpers + HMAC session). E2E: 1 Playwright smoke covering submit → approve → vote → already-voted → results.
- Design matches repo system: `Container`, `Button`, `Card` patterns, `gray-*` palette, `blue-600` focus rings.

Spec: `docs/superpowers/specs/2026-04-19-lightning-talk-voting-design.md`
Plan: `docs/superpowers/plans/2026-04-19-lightning-talk-voting.md`

## Test plan

- [ ] Set `ADMIN_TOKEN` and Vercel KV env vars (`KV_REST_API_URL`, `KV_REST_API_TOKEN`) on Vercel.
- [ ] Run locally: ``npm run lint && npx tsc --noEmit && npx vitest run && npm run build`` — all green.
- [ ] Visit ``/submit`` → fill form → see confirmation card with "Go vote for other talks" CTA.
- [ ] Visit ``/admin`` → sign in with ``ADMIN_TOKEN`` → approve a submission at ``/admin/submissions``.
- [ ] Visit ``/vote`` in incognito → pick up to 3 talks → submit → see success.
- [ ] Retry ``/vote`` with same incognito → "already voted" state.
- [ ] POST the same ballot again via curl → 200 ``alreadyRecorded: true``.
- [ ] POST a different ballot → 409 ``already-voted``.
- [ ] ``/admin/results`` shows ranked tally + CSV download.
- [ ] Playwright smoke: ``E2E_ADMIN_TOKEN=\$ADMIN_TOKEN npm run test:e2e -- lightning-talk-voting.spec.ts`` (requires KV + env).
- [ ] Generate two QR PNGs from the deployed ``/submit`` and ``/vote`` URLs; drop them into ``public/events/``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)