### PR TITLE
fix(voting): Upstash env aliases + route try/catch + clearer errors

### DIFF
--- a/src/app/api/admin/results/route.ts
+++ b/src/app/api/admin/results/route.ts
@@ -13,33 +13,38 @@ import {
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
-  if (!verifySession(session, Date.now())) {
-    return NextResponse.json({ ok: false }, { status: 401 });
+  try {
+    const session = cookies().get(ADMIN_SESSION_COOKIE)?.value;
+    if (!verifySession(session, Date.now())) {
+      return NextResponse.json({ ok: false }, { status: 401 });
+    }
+
+    const event = await getEventConfig();
+    const [subs, ballots, totalVoters] = await Promise.all([
+      listSubmissions(event.slug),
+      listBallots(event.slug),
+      voterCount(event.slug),
+    ]);
+    const approvedIds = new Set(subs.filter((s) => s.status === 'approved').map((s) => s.id));
+    const counts = tallyVotes(ballots, approvedIds);
+    const totalVotes = ballots.reduce((n, b) => n + b.submissionIds.length, 0);
+
+    const rows = subs.map((s) => ({ ...s, voteCount: counts.get(s.id) ?? 0 }));
+    const ranked = assignRanks(rows).map((r) => ({
+      id: r.id,
+      title: r.title,
+      speakerName: r.speakerName,
+      handle: r.handle,
+      contact: r.contact,
+      tag: r.tag,
+      status: r.status,
+      voteCount: r.voteCount,
+      rank: r.rank,
+    }));
+
+    return NextResponse.json({ totalVoters, totalVotes, results: ranked });
+  } catch (err) {
+    console.error('[api/admin/results] server error', err);
+    return NextResponse.json({ ok: false, error: 'server' }, { status: 500 });
   }
-
-  const event = await getEventConfig();
-  const [subs, ballots, totalVoters] = await Promise.all([
-    listSubmissions(event.slug),
-    listBallots(event.slug),
-    voterCount(event.slug),
-  ]);
-  const approvedIds = new Set(subs.filter((s) => s.status === 'approved').map((s) => s.id));
-  const counts = tallyVotes(ballots, approvedIds);
-  const totalVotes = ballots.reduce((n, b) => n + b.submissionIds.length, 0);
-
-  const rows = subs.map((s) => ({ ...s, voteCount: counts.get(s.id) ?? 0 }));
-  const ranked = assignRanks(rows).map((r) => ({
-    id: r.id,
-    title: r.title,
-    speakerName: r.speakerName,
-    handle: r.handle,
-    contact: r.contact,
-    tag: r.tag,
-    status: r.status,
-    voteCount: r.voteCount,
-    rank: r.rank,
-  }));
-
-  return NextResponse.json({ totalVoters, totalVotes, results: ranked });
 }

--- a/src/app/api/admin/submissions/route.ts
+++ b/src/app/api/admin/submissions/route.ts
@@ -22,29 +22,39 @@ function requireSession(): boolean {
 }
 
 export async function GET(req: Request) {
-  if (!requireSession()) return unauthorized();
-  const url = new URL(req.url);
-  const filter = (url.searchParams.get('status') ?? 'all') as SubmissionStatus | 'all';
-  const event = await getEventConfig();
-  const all = await listSubmissions(event.slug);
-  const submissions = filter === 'all' ? all : all.filter((s) => s.status === filter);
-  return NextResponse.json({ submissions });
+  try {
+    if (!requireSession()) return unauthorized();
+    const url = new URL(req.url);
+    const filter = (url.searchParams.get('status') ?? 'all') as SubmissionStatus | 'all';
+    const event = await getEventConfig();
+    const all = await listSubmissions(event.slug);
+    const submissions = filter === 'all' ? all : all.filter((s) => s.status === filter);
+    return NextResponse.json({ submissions });
+  } catch (err) {
+    console.error('[api/admin/submissions GET] server error', err);
+    return NextResponse.json({ ok: false, error: 'server' }, { status: 500 });
+  }
 }
 
 const patchSchema = z.object({ status: z.enum(['pending', 'approved', 'rejected']) });
 
 export async function PATCH(req: Request) {
-  if (!requireSession()) return unauthorized();
-  const url = new URL(req.url);
-  const id = url.searchParams.get('id');
-  if (!id) return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
-  const existing = await getSubmission(id);
-  if (!existing) return NextResponse.json({ ok: false, error: 'not-found' }, { status: 404 });
-  const json = await req.json().catch(() => null);
-  const parsed = patchSchema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+  try {
+    if (!requireSession()) return unauthorized();
+    const url = new URL(req.url);
+    const id = url.searchParams.get('id');
+    if (!id) return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+    const existing = await getSubmission(id);
+    if (!existing) return NextResponse.json({ ok: false, error: 'not-found' }, { status: 404 });
+    const json = await req.json().catch(() => null);
+    const parsed = patchSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+    }
+    await setSubmissionStatus(id, parsed.data.status);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('[api/admin/submissions PATCH] server error', err);
+    return NextResponse.json({ ok: false, error: 'server' }, { status: 500 });
   }
-  await setSubmissionStatus(id, parsed.data.status);
-  return NextResponse.json({ ok: true });
 }

--- a/src/app/api/submissions/route.ts
+++ b/src/app/api/submissions/route.ts
@@ -22,37 +22,42 @@ const bodySchema = z.object({
 });
 
 export async function POST(req: Request) {
-  const voter = cookies().get(VOTER_COOKIE)?.value;
-  if (!voter) {
-    return NextResponse.json({ ok: false, error: 'cookies-required' }, { status: 400 });
+  try {
+    const voter = cookies().get(VOTER_COOKIE)?.value;
+    if (!voter) {
+      return NextResponse.json({ ok: false, error: 'cookies-required' }, { status: 400 });
+    }
+
+    const event = await getEventConfig();
+    if (!isWithinWindow(event.submissionOpensAt, event.submissionClosesAt, new Date())) {
+      return NextResponse.json({ ok: false, error: 'closed' }, { status: 400 });
+    }
+
+    const json = await req.json().catch(() => null);
+    const parsed = bodySchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+    }
+    const { handle, contact } = parsed.data;
+
+    const afterIncr = await incrSubmitRate(event.slug, voter);
+    if (afterIncr > event.submissionRateLimitPerCookie24h) {
+      return NextResponse.json({ ok: false, error: 'rate-limited' }, { status: 429 });
+    }
+
+    const submission = await createSubmission({
+      event: event.slug,
+      speakerName: parsed.data.speakerName,
+      handle,
+      contact,
+      title: parsed.data.title,
+      intro: parsed.data.intro,
+      tag: parsed.data.tag,
+    });
+
+    return NextResponse.json({ ok: true, id: submission.id });
+  } catch (err) {
+    console.error('[api/submissions] server error', err);
+    return NextResponse.json({ ok: false, error: 'server' }, { status: 500 });
   }
-
-  const event = await getEventConfig();
-  if (!isWithinWindow(event.submissionOpensAt, event.submissionClosesAt, new Date())) {
-    return NextResponse.json({ ok: false, error: 'closed' }, { status: 400 });
-  }
-
-  const json = await req.json().catch(() => null);
-  const parsed = bodySchema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
-  }
-  const { handle, contact } = parsed.data;
-
-  const afterIncr = await incrSubmitRate(event.slug, voter);
-  if (afterIncr > event.submissionRateLimitPerCookie24h) {
-    return NextResponse.json({ ok: false, error: 'rate-limited' }, { status: 429 });
-  }
-
-  const submission = await createSubmission({
-    event: event.slug,
-    speakerName: parsed.data.speakerName,
-    handle,
-    contact,
-    title: parsed.data.title,
-    intro: parsed.data.intro,
-    tag: parsed.data.tag,
-  });
-
-  return NextResponse.json({ ok: true, id: submission.id });
 }

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -16,57 +16,62 @@ export const dynamic = 'force-dynamic';
 const bodySchema = z.object({ submissionIds: z.array(z.string().min(1)) });
 
 export async function POST(req: Request) {
-  const voter = cookies().get(VOTER_COOKIE)?.value;
-  if (!voter) {
-    return NextResponse.json({ ok: false, error: 'cookies-required' }, { status: 400 });
-  }
-
-  const event = await getEventConfig();
-  if (Date.now() >= new Date(event.votingClosesAt).getTime()) {
-    return NextResponse.json({ ok: false, error: 'closed' }, { status: 400 });
-  }
-
-  const json = await req.json().catch(() => null);
-  const parsed = bodySchema.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
-  }
-  const requested = parsed.data.submissionIds;
-
-  // Initial validation pass
-  const initial = await listSubmissions(event.slug);
-  const approvedIds = new Set(initial.filter((s) => s.status === 'approved').map((s) => s.id));
-  const first = validateBallot(requested, event.voteLimit, approvedIds);
-  if (!first.ok) {
-    return NextResponse.json({ ok: false, error: first.error }, { status: 400 });
-  }
-
-  // Idempotency / already-voted check
-  const existing = await getBallot(event.slug, voter);
-  if (existing) {
-    if (sameCanonicalBallot(existing.submissionIds, requested)) {
-      return NextResponse.json({ ok: true, recorded: existing.submissionIds.length, alreadyRecorded: true });
+  try {
+    const voter = cookies().get(VOTER_COOKIE)?.value;
+    if (!voter) {
+      return NextResponse.json({ ok: false, error: 'cookies-required' }, { status: 400 });
     }
-    return NextResponse.json({ ok: false, error: 'already-voted' }, { status: 409 });
+
+    const event = await getEventConfig();
+    if (Date.now() >= new Date(event.votingClosesAt).getTime()) {
+      return NextResponse.json({ ok: false, error: 'closed' }, { status: 400 });
+    }
+
+    const json = await req.json().catch(() => null);
+    const parsed = bodySchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'validation' }, { status: 400 });
+    }
+    const requested = parsed.data.submissionIds;
+
+    // Initial validation pass
+    const initial = await listSubmissions(event.slug);
+    const approvedIds = new Set(initial.filter((s) => s.status === 'approved').map((s) => s.id));
+    const first = validateBallot(requested, event.voteLimit, approvedIds);
+    if (!first.ok) {
+      return NextResponse.json({ ok: false, error: first.error }, { status: 400 });
+    }
+
+    // Idempotency / already-voted check
+    const existing = await getBallot(event.slug, voter);
+    if (existing) {
+      if (sameCanonicalBallot(existing.submissionIds, requested)) {
+        return NextResponse.json({ ok: true, recorded: existing.submissionIds.length, alreadyRecorded: true });
+      }
+      return NextResponse.json({ ok: false, error: 'already-voted' }, { status: 409 });
+    }
+
+    // Re-read right before writing — talks may have changed status
+    const fresh = await listSubmissions(event.slug);
+    const freshApproved = new Set(fresh.filter((s) => s.status === 'approved').map((s) => s.id));
+    const final = requested.filter((id) => freshApproved.has(id));
+    if (final.length === 0) {
+      return NextResponse.json({ ok: false, error: 'selection-unavailable' }, { status: 409 });
+    }
+
+    await writeBallot(event.slug, voter, {
+      submissionIds: final,
+      submittedAt: new Date().toISOString(),
+    });
+
+    const dropped = requested.length - final.length;
+    return NextResponse.json({
+      ok: true,
+      recorded: final.length,
+      ...(dropped > 0 ? { dropped } : {}),
+    });
+  } catch (err) {
+    console.error('[api/votes] server error', err);
+    return NextResponse.json({ ok: false, error: 'server' }, { status: 500 });
   }
-
-  // Re-read right before writing — talks may have changed status
-  const fresh = await listSubmissions(event.slug);
-  const freshApproved = new Set(fresh.filter((s) => s.status === 'approved').map((s) => s.id));
-  const final = requested.filter((id) => freshApproved.has(id));
-  if (final.length === 0) {
-    return NextResponse.json({ ok: false, error: 'selection-unavailable' }, { status: 409 });
-  }
-
-  await writeBallot(event.slug, voter, {
-    submissionIds: final,
-    submittedAt: new Date().toISOString(),
-  });
-
-  const dropped = requested.length - final.length;
-  return NextResponse.json({
-    ok: true,
-    recorded: final.length,
-    ...(dropped > 0 ? { dropped } : {}),
-  });
 }

--- a/src/app/submit/SubmissionForm.tsx
+++ b/src/app/submit/SubmissionForm.tsx
@@ -53,8 +53,13 @@ export function SubmissionForm({ disabled }: Props) {
         setErrorMsg('Please enable cookies and reload before submitting.');
         break;
       case 'validation':
-      default:
         setErrorMsg('Please fill in name, title, intro, and tick the consent box.');
+        break;
+      case 'server':
+        setErrorMsg('Server error — storage is unreachable. Please contact the organizer.');
+        break;
+      default:
+        setErrorMsg('Something went wrong. Please try again in a moment.');
     }
   }
 

--- a/src/app/vote/VoteClient.tsx
+++ b/src/app/vote/VoteClient.tsx
@@ -63,6 +63,9 @@ export function VoteClient({ cards, voteLimit }: { cards: Card[]; voteLimit: num
       case 'unknown-submission':
         setMessage('One of your selections is no longer available. Refresh and try again.');
         break;
+      case 'server':
+        setMessage('Server error — storage is unreachable. Please contact the organizer.');
+        break;
       default:
         setMessage('Could not record your vote. Try again.');
     }

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -1,0 +1,13 @@
+// Vercel's Marketplace Redis integration provisions UPSTASH_REDIS_REST_URL /
+// UPSTASH_REDIS_REST_TOKEN. @vercel/kv only reads KV_REST_API_URL /
+// KV_REST_API_TOKEN, so alias them before the client lazy-initializes.
+// Why: without this, prod throws "@vercel/kv: Missing required environment
+// variables" and every POST to /api/submissions or /api/votes 500s.
+if (!process.env.KV_REST_API_URL && process.env.UPSTASH_REDIS_REST_URL) {
+  process.env.KV_REST_API_URL = process.env.UPSTASH_REDIS_REST_URL;
+}
+if (!process.env.KV_REST_API_TOKEN && process.env.UPSTASH_REDIS_REST_TOKEN) {
+  process.env.KV_REST_API_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+}
+
+export { kv } from '@vercel/kv';

--- a/src/lib/voting.ts
+++ b/src/lib/voting.ts
@@ -102,7 +102,7 @@ export function shuffleWithSeed<T>(items: T[], seed: string): T[] {
   return arr;
 }
 
-import { kv } from '@vercel/kv';
+import { kv } from '@/lib/kv';
 import type { Submission, SubmissionStatus, Ballot } from '@/types/voting';
 
 const submissionKey = (id: string) => `submission:${id}`;


### PR DESCRIPTION
## Summary

- Fix 500 on `/api/submissions` and `/api/votes` in Vercel production after Vercel KV was migrated to the Upstash Redis Marketplace integration.
- Surface real server errors in Vercel Function logs (previously swallowed as unhandled exceptions → HTML 500).
- Fix misleading client error where the validation message was shown for any unknown failure.

## Root cause

Vercel's new Marketplace Redis integration provisions `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`. `@vercel/kv` only reads `KV_REST_API_URL` / `KV_REST_API_TOKEN` and throws `"Missing required environment variables"` on the first lazy `kv.*` access. The handler had no try/catch, so the response became a 500 with an HTML body; the client's `res.json().catch(() => ({}))` produced `{}`, fell through to the default branch, and showed "Please fill in name, title, intro, and tick the consent box." — even when all fields were filled.

## Changes

- `src/lib/kv.ts` (new) — aliases `UPSTASH_REDIS_REST_URL/TOKEN` → `KV_REST_API_URL/TOKEN` at module load, then re-exports `kv`. No-op when the `KV_REST_API_*` names are already present.
- `src/lib/voting.ts` — imports `kv` from `@/lib/kv` so the alias runs before the Proxy reads env vars on first access.
- `src/app/api/submissions/route.ts`, `src/app/api/votes/route.ts`, `src/app/api/admin/results/route.ts`, `src/app/api/admin/submissions/route.ts` — wrapped in try/catch; log with a tagged prefix and return `{ ok:false, error:'server' }` 500.
- `SubmissionForm.tsx`, `VoteClient.tsx` — split `validation` / `server` / `default` into distinct messages.

## Test plan

- [ ] `npm run lint && npx tsc --noEmit && npx vitest run` — 102 tests green
- [ ] Local: /submit happy path returns the success card; empty form → "Please fill in…" message
- [ ] After deploy: submit a talk on prod; if still failing, check Vercel Function logs for `[api/submissions] server error` stack trace
- [ ] /vote submit works end-to-end on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)