### PR TITLE
feat(vote): read-only results view after voting (reland)

### DIFF
--- a/src/app/vote/VoteClient.tsx
+++ b/src/app/vote/VoteClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/Button';
 
 interface Card {
@@ -11,6 +12,7 @@ interface Card {
 }
 
 export function VoteClient({ cards, voteLimit }: { cards: Card[]; voteLimit: number }) {
+  const router = useRouter();
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState<string>('');
@@ -36,14 +38,7 @@ export function VoteClient({ cards, voteLimit }: { cards: Card[]; voteLimit: num
     const data = await res.json().catch(() => ({}));
     if (res.ok && data.ok) {
       setStatus('success');
-      const dropped = Number(data.dropped ?? 0);
-      setMessage(
-        dropped > 0
-          ? 'Vote recorded, but some selections were no longer available.'
-          : data.alreadyRecorded
-            ? 'You already submitted this ballot. Nothing changed.'
-            : 'Thanks — your vote has been recorded.'
-      );
+      router.refresh();
       return;
     }
     setStatus('error');
@@ -69,14 +64,6 @@ export function VoteClient({ cards, voteLimit }: { cards: Card[]; voteLimit: num
       default:
         setMessage('Could not record your vote. Try again.');
     }
-  }
-
-  if (status === 'success') {
-    return (
-      <div className="rounded-lg border border-green-200 bg-green-50 p-6 shadow-sm">
-        <p className="text-lg font-semibold text-green-900">{message}</p>
-      </div>
-    );
   }
 
   return (
@@ -131,9 +118,11 @@ export function VoteClient({ cards, voteLimit }: { cards: Card[]; voteLimit: num
           type="button"
           size="lg"
           onClick={submit}
-          disabled={selected.size === 0 || status === 'submitting'}
+          disabled={selected.size === 0 || status === 'submitting' || status === 'success'}
         >
-          {status === 'submitting' ? 'Submitting…' : `Submit vote${selected.size > 0 ? ` (${selected.size})` : ''}`}
+          {status === 'submitting' || status === 'success'
+            ? 'Submitting…'
+            : `Submit vote${selected.size > 0 ? ` (${selected.size})` : ''}`}
         </Button>
       </div>
     </div>

--- a/src/app/vote/VotedView.tsx
+++ b/src/app/vote/VotedView.tsx
@@ -1,0 +1,96 @@
+interface Card {
+  id: string;
+  title: string;
+  speakerName: string;
+  intro: string;
+  voteCount: number;
+}
+
+interface Props {
+  yourVotes: Card[];
+  otherTalks: Card[];
+  submittedAt?: string;
+  closed: boolean;
+}
+
+function voteLabel(n: number) {
+  return `${n} ${n === 1 ? 'vote' : 'votes'}`;
+}
+
+function TalkCard({ card, isMine }: { card: Card; isMine: boolean }) {
+  return (
+    <div
+      className={`relative flex h-full flex-col rounded-lg border p-5 shadow-sm ${
+        isMine ? 'border-blue-600 bg-blue-50 ring-2 ring-blue-600' : 'border-gray-200 bg-white'
+      }`}
+    >
+      <div className="absolute right-4 top-4 flex items-center gap-2">
+        {isMine && (
+          <span className="rounded-full bg-blue-600 px-2 py-0.5 text-xs font-semibold text-white">
+            Your pick
+          </span>
+        )}
+        <span className="rounded-full bg-gray-900 px-2 py-0.5 text-xs font-semibold text-white">
+          {voteLabel(card.voteCount)}
+        </span>
+      </div>
+      <h3 className="pr-28 text-lg font-semibold text-gray-900">{card.title}</h3>
+      <p className="mt-1 text-xs font-medium uppercase tracking-wide text-gray-500">
+        {card.speakerName}
+      </p>
+      <p className="mt-3 text-sm leading-6 text-gray-600">{card.intro}</p>
+    </div>
+  );
+}
+
+export function VotedView({ yourVotes, otherTalks, submittedAt, closed }: Props) {
+  return (
+    <div className="space-y-8">
+      <div className="rounded-lg border border-green-200 bg-green-50 p-5 shadow-sm">
+        {submittedAt ? (
+          <>
+            <p className="text-base font-semibold text-green-900">
+              Your vote is locked in — {yourVotes.length}{' '}
+              {yourVotes.length === 1 ? 'selection' : 'selections'} recorded.
+            </p>
+            <p className="mt-1 text-sm text-green-800">
+              Submitted {new Date(submittedAt).toLocaleString()}. Votes cannot be changed.
+            </p>
+          </>
+        ) : (
+          <p className="text-base font-semibold text-green-900">
+            {closed ? 'Voting is closed.' : 'Voting results so far.'}
+          </p>
+        )}
+      </div>
+
+      {yourVotes.length > 0 && (
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900">Your picks</h2>
+          <ul className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {yourVotes.map((c) => (
+              <li key={c.id}>
+                <TalkCard card={c} isMine />
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {otherTalks.length > 0 && (
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900">
+            {yourVotes.length > 0 ? 'Other talks' : 'All talks'}
+          </h2>
+          <ul className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {otherTalks.map((c) => (
+              <li key={c.id}>
+                <TalkCard card={c} isMine={false} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/app/vote/page.tsx
+++ b/src/app/vote/page.tsx
@@ -3,11 +3,14 @@ import { VOTER_COOKIE } from '@/middleware';
 import {
   getBallot,
   getEventConfig,
+  listBallots,
   listSubmissions,
   shuffleWithSeed,
+  tallyVotes,
 } from '@/lib/voting';
 import { Container } from '@/components/ui/Container';
 import { VoteClient } from './VoteClient';
+import { VotedView } from './VotedView';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,44 +24,59 @@ export default async function VotePage() {
     voter ? getBallot(event.slug, voter) : Promise.resolve(null),
   ]);
   const approved = all.filter((s) => s.status === 'approved');
-  const cards = shuffleWithSeed(
-    approved.map((s) => ({
-      id: s.id,
-      title: s.title,
-      speakerName: s.speakerName,
-      intro: s.intro,
-    })),
-    seed
-  );
+
+  const showReadOnly = Boolean(existing) || closed;
+  const ballots = showReadOnly ? await listBallots(event.slug) : [];
 
   return (
     <section className="py-16 sm:py-20">
       <Container>
         <div className="mx-auto max-w-3xl">
           <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-            Vote for talks you want to hear
+            {existing ? 'Your vote is in' : closed ? 'Voting is closed' : 'Vote for talks you want to hear'}
           </h1>
 
           <div className="mt-10">
-            {existing ? (
-              <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-                <p className="text-lg font-semibold text-gray-900">
-                  You&apos;ve already voted from this browser.
-                </p>
-                <p className="mt-2 text-sm text-gray-600">
-                  {existing.submissionIds.length} selection(s) recorded at{' '}
-                  {new Date(existing.submittedAt).toLocaleString()}.
-                </p>
-              </div>
-            ) : closed ? (
-              <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-                <p className="text-lg font-semibold text-gray-900">Voting is closed.</p>
-                <p className="mt-2 text-sm text-gray-600">Results will be announced soon.</p>
-              </div>
+            {showReadOnly ? (
+              (() => {
+                const approvedIds = new Set(approved.map((s) => s.id));
+                const counts = tallyVotes(ballots, approvedIds);
+                const cards = approved.map((s) => ({
+                  id: s.id,
+                  title: s.title,
+                  speakerName: s.speakerName,
+                  intro: s.intro,
+                  voteCount: counts.get(s.id) ?? 0,
+                }));
+                const mine = new Set(existing?.submissionIds ?? []);
+                const byCountDesc = (a: { voteCount: number }, b: { voteCount: number }) =>
+                  b.voteCount - a.voteCount;
+                const yourVotes = cards.filter((c) => mine.has(c.id)).sort(byCountDesc);
+                const otherTalks = cards.filter((c) => !mine.has(c.id)).sort(byCountDesc);
+                return (
+                  <VotedView
+                    yourVotes={yourVotes}
+                    otherTalks={otherTalks}
+                    submittedAt={existing?.submittedAt}
+                    closed={closed}
+                  />
+                );
+              })()
             ) : approved.length === 0 ? (
               <p className="text-gray-600">No talks are available for voting yet.</p>
             ) : (
-              <VoteClient cards={cards} voteLimit={event.voteLimit} />
+              <VoteClient
+                cards={shuffleWithSeed(
+                  approved.map((s) => ({
+                    id: s.id,
+                    title: s.title,
+                    speakerName: s.speakerName,
+                    intro: s.intro,
+                  })),
+                  seed
+                )}
+                voteLimit={event.voteLimit}
+              />
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary

Relands PR #67 onto `main`. PR #67 merged into the stale `fix/voting-kv-upstash-env-aliases` branch *after* PR #66 had already merged to `main`, so its changes never reached production. Same commit, cherry-picked onto a fresh branch off `main`.

- After voting, `/vote` now shows the full talk list with vote counts instead of the tiny "you've already voted" card.
- Your picks are pinned to the top with a blue ring + "Your pick" badge; other talks sit below, sorted by vote count descending.
- Voting-closed state uses the same view (no picks section) with a "Voting is closed" banner.

## Files

- `src/app/vote/VotedView.tsx` (new) — server component with banner + "Your picks" + "Other talks" sections; each card has a vote-count pill.
- `src/app/vote/page.tsx` — branches on `Boolean(existing) || closed`. Lazy-fetches `listBallots` only when the read-only view is needed. Uses `tallyVotes` for per-talk counts.
- `src/app/vote/VoteClient.tsx` — on successful `POST /api/votes`, calls `router.refresh()`; server re-renders with `VotedView`. Intermediate success card removed.

## Test plan

- [ ] `npm run lint && npx tsc --noEmit && npx vitest run` — 102 tests green (verified)
- [ ] Vote in a fresh session → `VotedView` with your picks highlighted on top
- [ ] Reload → `VotedView` persists (ballot in KV)
- [ ] Clear `zts_voter` cookie → back to `VoteClient`
- [ ] Advance `votingClosesAt` → "Voting is closed" `VotedView` without the picks section

🤖 Generated with [Claude Code](https://claude.com/claude-code)