### PR TITLE
feat(vote): auto-refresh /vote while voting is open

### DIFF
--- a/src/app/vote/AutoRefresh.tsx
+++ b/src/app/vote/AutoRefresh.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+// Polls router.refresh() on an interval so new submissions (after admin
+// approval) and updated vote counts show up without a manual reload. Pauses
+// when the tab is hidden so idle tabs don't hammer Upstash.
+export function AutoRefresh({ intervalMs = 10000 }: { intervalMs?: number }) {
+  const router = useRouter();
+  const lastTick = useRef(Date.now());
+
+  useEffect(() => {
+    function tick() {
+      if (document.visibilityState !== 'visible') return;
+      router.refresh();
+      lastTick.current = Date.now();
+    }
+    const id = window.setInterval(tick, intervalMs);
+    function onVisibility() {
+      if (
+        document.visibilityState === 'visible' &&
+        Date.now() - lastTick.current >= intervalMs
+      ) {
+        tick();
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.clearInterval(id);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [intervalMs, router]);
+
+  return null;
+}

--- a/src/app/vote/page.tsx
+++ b/src/app/vote/page.tsx
@@ -9,6 +9,7 @@ import {
   tallyVotes,
 } from '@/lib/voting';
 import { Container } from '@/components/ui/Container';
+import { AutoRefresh } from './AutoRefresh';
 import { VoteClient } from './VoteClient';
 import { VotedView } from './VotedView';
 
@@ -32,6 +33,7 @@ export default async function VotePage() {
     <section className="py-16 sm:py-20">
       <Container>
         <div className="mx-auto max-w-3xl">
+          {!closed && <AutoRefresh intervalMs={10000} />}
           <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
             {existing ? 'Your vote is in' : closed ? 'Voting is closed' : 'Vote for talks you want to hear'}
           </h1>


### PR DESCRIPTION
## Summary

Poll `router.refresh()` every 10 s on `/vote` so:

- New approved submissions appear for voters in real time (organizer approves a talk on `/admin` → it shows up on `/vote` within ~10 s).
- Vote counts in `VotedView` tick up as others submit ballots.
- Empty-state page becomes populated once the first talk is approved.

Polling pauses when the tab is hidden (`document.visibilityState`) and resumes on focus — idle tabs don't burn Upstash reads.

## Files

- `src/app/vote/AutoRefresh.tsx` (new) — tiny `'use client'` component that calls `router.refresh()` on an interval. Listens to `visibilitychange` and fires immediately on tab-focus if the last tick was over `intervalMs` ago.
- `src/app/vote/page.tsx` — mounts `<AutoRefresh intervalMs={10000} />` only while voting is open (`!closed`). No polling after `votingClosesAt` since counts are final.

## Why polling, not SSE/WebSockets

Vercel serverless can't hold long-lived connections; SSE/WebSockets need an external relay (Pusher/Ably). For meetup-scale traffic (~40 voters × 30 min × 10 s ≈ 7 k reads) polling is well within Upstash's free tier. `router.refresh()` only re-fetches the RSC payload, so `VoteClient`'s `selected` set and scroll position survive the refresh.

## Test plan

- [ ] `npm run lint && npx tsc --noEmit && npx vitest run` — 102 tests green (verified)
- [ ] Open `/vote` in two browsers. In browser A vote for a talk; browser B's `VotedView` shows count+1 within 10 s.
- [ ] Approve a new submission on `/admin`; `/vote` in another tab shows the new card within 10 s.
- [ ] Switch away from `/vote` tab — polling pauses (check DevTools Network).
- [ ] Switch back — a refresh fires within 10 s.
- [ ] Advance `votingClosesAt` → polling stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)