### PR TITLE
blog: add Get Involved CTA to May 19 recap

### DIFF
--- a/content/blog/claude-sydney-meetup-may-19-recap.mdx
+++ b/content/blog/claude-sydney-meetup-may-19-recap.mdx
@@ -135,4 +135,8 @@ It is free. Spots are limited.
 
 **[Register for the June 16 meetup on Luma](https://luma.com/in9tpvja)**
 
+## Get Involved
+
+Want to speak at a future meetup, sponsor an event, or help shape the community? **[Get involved with 02Ship →](https://www.02ship.com/get-involved)**
+
 See you there.


### PR DESCRIPTION
## Summary
- Add a secondary CTA section to \`content/blog/claude-sydney-meetup-may-19-recap.mdx\` pointing to https://www.02ship.com/get-involved
- Placed after the Luma registration link so readers who cannot attend the next meetup still have a path to speak, sponsor, or contribute

## Test plan
- [ ] Visit \`/blog/claude-sydney-meetup-may-19-recap\` after deploy and confirm the new "Get Involved" section renders with the working link
- [ ] Confirm the existing Luma registration CTA and sign-off are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)