### PR TITLE
ships: render homepage screenshots on /ships list cards

### DIFF
--- a/src/app/ships/page.tsx
+++ b/src/app/ships/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import Image from 'next/image';
 import { Container } from '@/components/ui/Container';
 import { getAllShips } from '@/lib/content';
 
@@ -42,21 +43,33 @@ export default async function ShipsPage() {
                   href={`/ships/${ship.slug}`}
                   className="group flex flex-col rounded-xl border border-gray-200 transition-all hover:border-gray-300 hover:shadow-md"
                 >
-                  <div className="flex h-48 items-center justify-center rounded-t-xl bg-gray-100">
-                    <svg
-                      className="h-12 w-12 text-gray-400"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      strokeWidth={1}
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.631 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.841m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 01-2.448-2.448 14.9 14.9 0 01.06-.312m-2.24 2.39a4.493 4.493 0 00-1.757 4.306 4.493 4.493 0 004.306-1.758M16.5 9a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"
+                  {ship.screenshot ? (
+                    <div className="relative h-48 overflow-hidden rounded-t-xl bg-gray-100">
+                      <Image
+                        src={ship.screenshot}
+                        alt={`${ship.title} homepage screenshot`}
+                        fill
+                        sizes="(min-width: 768px) 50vw, 100vw"
+                        className="object-cover object-top"
                       />
-                    </svg>
-                  </div>
+                    </div>
+                  ) : (
+                    <div className="flex h-48 items-center justify-center rounded-t-xl bg-gray-100">
+                      <svg
+                        className="h-12 w-12 text-gray-400"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        strokeWidth={1}
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.631 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.841m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 01-2.448-2.448 14.9 14.9 0 01.06-.312m-2.24 2.39a4.493 4.493 0 00-1.757 4.306 4.493 4.493 0 004.306-1.758M16.5 9a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"
+                        />
+                      </svg>
+                    </div>
+                  )}
                   <div className="flex flex-1 flex-col p-6">
                     {ship.cohort && (
                       <span className="mb-2 inline-block w-fit rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">


### PR DESCRIPTION
## Summary
- Render ship.screenshot on each card on /ships using next/image with object-cover object-top
- Fall back to the existing rocket placeholder when a ship has no screenshot
- Reuses screenshot assets and JSON fields shipped in #78

## Test plan
- [ ] /ships shows homepage screenshots for ai-uni-tutor, clawfy, and 02ship cards
- [ ] A ship without a screenshot still renders the rocket placeholder card
- [ ] Card hover/border behavior is unchanged
- [ ] npm run lint and npx tsc --noEmit are clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)