### PR TITLE
Fix Shaon Diwakar's LinkedIn URL in April 21 recap

### DIFF
--- a/content/blog/claude-sydney-meetup-april-21-recap.mdx
+++ b/content/blog/claude-sydney-meetup-april-21-recap.mdx
@@ -26,7 +26,7 @@ The event page is here: [**Claude Sydney Meetup — How People Actually Use Clau
 
 ## Talk 1: Claude Workflows Worth Stealing
 
-[**Shaon Diwakar**](https://www.linkedin.com/in/shaon-diwakar/) — Founder of **Dini Labs**, ex-Meta (Instagram/Threads), NewsMaven, Tyro, EY — opened with a rapid-fire tour through 14 Claude workflows that have made it into his daily practice. His framing: *these are all "worth stealing"* — pick the ones that match your stack.
+[**Shaon Diwakar**](https://www.linkedin.com/in/shaond/) — Founder of **Dini Labs**, ex-Meta (Instagram/Threads), NewsMaven, Tyro, EY — opened with a rapid-fire tour through 14 Claude workflows that have made it into his daily practice. His framing: *these are all "worth stealing"* — pick the ones that match your stack.
 
 **[View Shaon's slide deck →](https://docs.google.com/presentation/d/1LkeEg4HESCkZfJzN-8w0vCcBE6XJhjBIgKqLdKT0GSo/edit?usp=sharing)**
 


### PR DESCRIPTION
## Summary
- Corrects the LinkedIn link for Shaon Diwakar in the April 21 meetup recap: `/in/shaon-diwakar/` → `/in/shaond/`.

## Test plan
- [ ] Click the Shaon Diwakar link on `/blog/claude-sydney-meetup-april-21-recap` and confirm it resolves to the correct profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)