### PR TITLE
feat(nav): move Get Involved into About dropdown

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -9,7 +9,6 @@ const navLinks = [
   { label: 'Courses', href: '/courses' },
   { label: 'Daily News', href: '/news' },
   { label: 'Events', href: '/events' },
-  { label: 'Get Involved', href: '/get-involved' },
 ];
 
 const shipsLinks = [
@@ -19,6 +18,7 @@ const shipsLinks = [
 
 const aboutLinks = [
   { label: 'Our Story', href: '/about' },
+  { label: 'Get Involved', href: '/get-involved' },
   { label: 'Blog', href: '/blog' },
   { label: 'Community', href: '/community' },
 ];


### PR DESCRIPTION
## Summary
Moves the **Get Involved** link out of the top-level navigation and into the **About** dropdown, positioned between **Our Story** and **Blog**.

Both desktop and mobile menus read from the same `navLinks`/`aboutLinks` arrays in `src/components/layout/Header.tsx`, so the change applies in both views.

## Changes
- Remove `Get Involved` from `navLinks`
- Add `Get Involved` to `aboutLinks` between `Our Story` and `Blog`

## Testing
- `npx tsc --noEmit` passes
- `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)