### PR TITLE
feat: unify card styles, active nav, course UX, and homepage copy

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -21,8 +21,10 @@ export default function AboutPage() {
 
           <div className="mt-8 space-y-6 text-lg text-gray-600">
             <p>
-              02Ship is a learning platform designed to help absolute beginners
-              build and ship their ideas using AI coding tools like Claude Code.
+              02Ship — short for{' '}
+              <strong className="text-gray-900">Zero to Ship</strong> — is a
+              learning platform designed to help absolute beginners build and
+              ship their ideas using AI coding tools like Claude Code.
             </p>
 
             <p>

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Container } from '@/components/ui/Container';
 import { Button } from '@/components/ui/Button';
+import { cn, cardSurface, cardHover } from '@/lib/utils';
 
 export const metadata: Metadata = {
   title: 'Community — Join Sydney\'s Claude Builder Community',
@@ -176,7 +177,7 @@ export default function CommunityPage() {
             {whatWeDoItems.map((item) => (
               <div
                 key={item.title}
-                className="rounded-lg border border-gray-200 p-6"
+                className={cn(cardSurface, 'p-6')}
               >
                 <h3 className="text-lg font-semibold text-gray-900">
                   {item.title}
@@ -199,7 +200,7 @@ export default function CommunityPage() {
                 href={community.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex flex-col items-center rounded-xl border border-gray-200 p-6 text-center transition-all hover:border-gray-300 hover:shadow-md"
+                className={cn(cardSurface, cardHover, 'flex flex-col items-center p-6 text-center')}
               >
                 <div className="text-gray-700">{community.icon}</div>
                 <h3 className="mt-4 text-lg font-semibold text-gray-900">
@@ -241,7 +242,7 @@ export default function CommunityPage() {
             href="https://forms.gle/wT2d2zZ47waQAviC8"
             target="_blank"
             rel="noopener noreferrer"
-            className="block rounded-xl border border-amber-200 bg-amber-50 p-6 transition-all hover:border-amber-300 hover:shadow-md"
+            className="block rounded-lg border border-amber-200 bg-amber-50 p-6 transition-shadow hover:shadow-md"
           >
             <div className="flex items-start gap-4">
               <span className="text-3xl" aria-hidden="true">

--- a/src/app/courses/[series]/[lesson]/page.tsx
+++ b/src/app/courses/[series]/[lesson]/page.tsx
@@ -1,10 +1,6 @@
 import { notFound } from 'next/navigation';
-import Link from 'next/link';
-import { Container } from '@/components/ui/Container';
-import { VideoPlayer } from '@/components/courses/VideoPlayer';
-import { Button } from '@/components/ui/Button';
+import { LessonContent } from '@/components/courses/LessonContent';
 import { getLessonBySlug, getSeriesBySlug, getAllSeries } from '@/lib/content';
-import { LessonActionsClient } from '@/components/courses/LessonActionsClient';
 
 interface LessonPageProps {
   params: Promise<{
@@ -31,13 +27,18 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: LessonPageProps) {
   const { series: seriesSlug, lesson: lessonSlug } = await params;
-  const lesson = await getLessonBySlug(seriesSlug, lessonSlug);
+  const series = await getSeriesBySlug(seriesSlug);
+  const lesson = series?.lessons.find((l) => l.slug === lessonSlug);
 
-  if (!lesson) {
+  if (!series || !lesson) {
     return {
       title: 'Lesson Not Found - 02Ship',
     };
   }
+
+  // The first lesson is canonical at the course root.
+  const isFirst = series.lessons[0]?.slug === lessonSlug;
+  const canonical = isFirst ? `/courses/${seriesSlug}` : `/courses/${seriesSlug}/${lessonSlug}`;
 
   return {
     title: lesson.title,
@@ -45,10 +46,10 @@ export async function generateMetadata({ params }: LessonPageProps) {
     openGraph: {
       title: lesson.title,
       description: lesson.description,
-      url: `/courses/${seriesSlug}/${lesson.slug}`,
+      url: canonical,
       type: 'article',
     },
-    alternates: { canonical: `/courses/${seriesSlug}/${lesson.slug}` },
+    alternates: { canonical },
   };
 }
 
@@ -77,243 +78,13 @@ export default async function LessonPage({ params }: LessonPageProps) {
     },
   };
 
-  const currentIndex = series.lessons.findIndex((l) => l.slug === lessonSlug);
-  const previousLesson = currentIndex > 0 ? series.lessons[currentIndex - 1] : null;
-  const nextLesson =
-    currentIndex < series.lessons.length - 1 ? series.lessons[currentIndex + 1] : null;
-
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(lessonJsonLd) }}
       />
-      <div className="py-20">
-        <Container>
-          <div className="mx-auto max-w-4xl">
-            <div className="mb-6">
-              <Link
-                href={`/courses/${seriesSlug}`}
-                className="text-sm font-medium text-blue-600 hover:text-blue-700"
-              >
-                &larr; Back to {series.title}
-              </Link>
-            </div>
-
-            <h1 className="text-4xl font-bold tracking-tight text-gray-900">{lesson.title}</h1>
-            <p className="mt-4 text-lg text-gray-600">{lesson.description}</p>
-            <p className="mt-2 text-sm text-gray-600">Duration: {lesson.duration}</p>
-            <LessonActionsClient seriesSlug={seriesSlug} lessonSlug={lessonSlug} />
-
-            {/* Learning Objectives */}
-            {lesson.learningObjectives && lesson.learningObjectives.length > 0 && (
-              <div className="mt-8 rounded-lg bg-blue-50 p-6">
-                <h2 className="text-xl font-semibold text-gray-900">Learning Objectives</h2>
-                <p className="mt-2 text-sm text-gray-600">
-                  By the end of this lesson, you will be able to:
-                </p>
-                <ul className="mt-4 space-y-2">
-                  {lesson.learningObjectives.map((objective, index) => (
-                    <li key={index} className="flex items-start">
-                      <span className="mr-2 text-blue-600">&#10003;</span>
-                      <span className="text-gray-700">{objective}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            {/* Videos Section */}
-            {lesson.videos && lesson.videos.length > 0 ? (
-              <div className="mt-12">
-                <h2 className="text-2xl font-bold text-gray-900">Videos</h2>
-                <div className="mt-6 space-y-8">
-                  {lesson.videos.map((video, index) => (
-                    <div key={index} className="rounded-lg border border-gray-200 p-6">
-                      <h3 className="text-xl font-semibold text-gray-900">{video.title}</h3>
-                      <p className="mt-2 text-gray-600">{video.description}</p>
-                      {video.estimatedDuration && (
-                        <p className="mt-1 text-sm text-gray-500">
-                          Duration: {video.estimatedDuration}
-                        </p>
-                      )}
-                      <div className="mt-4">
-                        {video.youtubeId && video.youtubeId !== '[To be recorded]' ? (
-                          <VideoPlayer youtubeId={video.youtubeId} title={video.title} />
-                        ) : (
-                          <div className="flex h-64 items-center justify-center rounded-lg bg-gray-100">
-                            <p className="text-gray-500">Video coming soon</p>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ) : lesson.youtubeId ? (
-              // Legacy single video support
-              <div className="mt-8">
-                <VideoPlayer youtubeId={lesson.youtubeId} title={lesson.title} />
-              </div>
-            ) : null}
-
-            {/* Text Sections */}
-            {lesson.textSections && lesson.textSections.length > 0 && (
-              <div className="mt-12">
-                <h2 className="text-2xl font-bold text-gray-900">Key Concepts</h2>
-                <div className="mt-6 space-y-6">
-                  {lesson.textSections.map((section, index) => (
-                    <div key={index} className="rounded-lg bg-gray-50 p-6">
-                      <h3 className="text-lg font-semibold text-gray-900">{section.title}</h3>
-                      <div className="mt-3 whitespace-pre-wrap text-gray-700">
-                        {section.content}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Common Mistakes */}
-            {lesson.commonMistakes && lesson.commonMistakes.length > 0 && (
-              <div className="mt-12">
-                <h2 className="text-2xl font-bold text-gray-900">Common Mistakes & Pitfalls</h2>
-                <div className="mt-6 space-y-4">
-                  {lesson.commonMistakes.map((item, index) => (
-                    <div
-                      key={index}
-                      className="rounded-lg border-l-4 border-yellow-500 bg-yellow-50 p-4"
-                    >
-                      <h3 className="font-semibold text-gray-900">
-                        &#10060; {item.mistake}
-                      </h3>
-                      <p className="mt-1 text-gray-700">{item.explanation}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Exercises */}
-            {lesson.exercises && lesson.exercises.length > 0 && (
-              <div className="mt-12">
-                <h2 className="text-2xl font-bold text-gray-900">Exercises</h2>
-                <div className="mt-6 space-y-6">
-                  {lesson.exercises.map((exercise, index) => (
-                    <div key={index} className="rounded-lg border border-gray-200 p-6">
-                      <div className="flex items-start justify-between">
-                        <h3 className="text-lg font-semibold text-gray-900">
-                          Exercise {index + 1}: {exercise.title}
-                        </h3>
-                        <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700">
-                          {exercise.estimatedTime}
-                        </span>
-                      </div>
-                      <p className="mt-3 text-gray-700">{exercise.description}</p>
-                      <div className="mt-4">
-                        <p className="text-sm font-medium text-gray-900">Expected Output:</p>
-                        <p className="mt-1 text-gray-600">{exercise.output}</p>
-                      </div>
-                      {Array.isArray(exercise.successCriteria) ? (
-                        <div className="mt-4">
-                          <p className="text-sm font-medium text-gray-900">Success Criteria:</p>
-                          <ul className="mt-2 space-y-1">
-                            {exercise.successCriteria.map((criteria, idx) => (
-                              <li key={idx} className="flex items-start text-sm text-gray-600">
-                                <span className="mr-2">&bull;</span>
-                                <span>{criteria}</span>
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                      ) : (
-                        <div className="mt-4">
-                          <p className="text-sm italic text-gray-600">
-                            {exercise.successCriteria}
-                          </p>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Reflection Questions */}
-            {lesson.reflectionQuestions && lesson.reflectionQuestions.length > 0 && (
-              <div className="mt-12">
-                <h2 className="text-2xl font-bold text-gray-900">Lesson Reflection</h2>
-                <div className="mt-6 rounded-lg bg-purple-50 p-6">
-                  <p className="text-sm text-gray-600">
-                    Take a moment to reflect on what you&apos;ve learned:
-                  </p>
-                  <ul className="mt-4 space-y-3">
-                    {lesson.reflectionQuestions.map((question, index) => (
-                      <li key={index} className="text-gray-700">
-                        <span className="font-medium">{index + 1}.</span> {question}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            )}
-
-            {/* Resources */}
-            {lesson.resources && lesson.resources.length > 0 && (
-              <div className="mt-12">
-                <h2 className="text-2xl font-bold text-gray-900">Resources & Further Reading</h2>
-                <div className="mt-6 space-y-3">
-                  {lesson.resources.map((resource, index) => (
-                    <a
-                      key={index}
-                      href={resource.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center text-blue-600 hover:text-blue-700"
-                    >
-                      <span className="mr-2">&#128214;</span>
-                      <span>{resource.title}</span>
-                      <span className="ml-2">&rarr;</span>
-                    </a>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Legacy Transcript */}
-            {lesson.transcript && (
-              <div className="mt-12">
-                <h2 className="text-2xl font-bold text-gray-900">Transcript</h2>
-                <div className="mt-4 whitespace-pre-wrap text-gray-600">{lesson.transcript}</div>
-              </div>
-            )}
-
-            {/* Navigation */}
-            <div className="mt-12 flex items-center justify-between border-t border-gray-200 pt-8">
-              <div>
-                {previousLesson ? (
-                  <Link href={`/courses/${seriesSlug}/${previousLesson.slug}`}>
-                    <Button variant="outline">&larr; Previous Lesson</Button>
-                  </Link>
-                ) : (
-                  <div />
-                )}
-              </div>
-              <div>
-                {nextLesson ? (
-                  <Link href={`/courses/${seriesSlug}/${nextLesson.slug}`}>
-                    <Button>Next Lesson &rarr;</Button>
-                  </Link>
-                ) : (
-                  <Link href={`/courses/${seriesSlug}`}>
-                    <Button variant="outline">Back to Course</Button>
-                  </Link>
-                )}
-              </div>
-            </div>
-          </div>
-        </Container>
-      </div>
+      <LessonContent series={series} lesson={lesson} />
     </>
   );
 }

--- a/src/app/courses/[series]/layout.tsx
+++ b/src/app/courses/[series]/layout.tsx
@@ -1,0 +1,33 @@
+import { notFound } from 'next/navigation';
+import { Container } from '@/components/ui/Container';
+import { CourseSidebar } from '@/components/courses/CourseSidebar';
+import { getSeriesBySlug } from '@/lib/content';
+
+interface CourseLayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ series: string }>;
+}
+
+export default async function CourseLayout({ children, params }: CourseLayoutProps) {
+  const { series: seriesSlug } = await params;
+  const series = await getSeriesBySlug(seriesSlug);
+
+  if (!series) {
+    notFound();
+  }
+
+  return (
+    <div className="py-12">
+      <Container>
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,1fr)_18rem] lg:gap-12 lg:grid-cols-[minmax(0,1fr)_20rem]">
+          <main className="min-w-0">{children}</main>
+          <CourseSidebar
+            seriesSlug={series.slug}
+            seriesTitle={series.title}
+            lessons={series.lessons.map((l) => ({ slug: l.slug, title: l.title }))}
+          />
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/src/app/courses/[series]/page.tsx
+++ b/src/app/courses/[series]/page.tsx
@@ -1,9 +1,6 @@
 import { notFound } from 'next/navigation';
-import { Container } from '@/components/ui/Container';
-import { LessonCard } from '@/components/courses/LessonCard';
+import { LessonContent } from '@/components/courses/LessonContent';
 import { getSeriesBySlug, getAllSeries } from '@/lib/content';
-import { SeriesProgressClient } from '@/components/courses/SeriesProgressClient';
-import { BookmarkButton } from '@/components/bookmarks/BookmarkButton';
 
 interface SeriesPageProps {
   params: Promise<{
@@ -48,6 +45,8 @@ export default async function SeriesPage({ params }: SeriesPageProps) {
     notFound();
   }
 
+  const firstLesson = series.lessons[0];
+
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.02ship.com';
   const courseJsonLd = {
     '@context': 'https://schema.org',
@@ -70,35 +69,14 @@ export default async function SeriesPage({ params }: SeriesPageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(courseJsonLd) }}
       />
-      <div className="py-20">
-        <Container>
-          <div className="mx-auto max-w-2xl">
-            <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-              {series.title}
-            </h1>
-            <p className="mt-4 text-lg text-gray-600">{series.description}</p>
-            <p className="mt-2 text-sm text-gray-600">
-              {series.lessons.length} {series.lessons.length === 1 ? 'lesson' : 'lessons'}
-            </p>
-            <div className="mt-3 flex items-center gap-3">
-              <BookmarkButton contentType="series" contentSlug={series.slug} />
-            </div>
-            <SeriesProgressClient seriesSlug={series.slug} totalLessons={series.lessons.length} />
-          </div>
-
-          <div className="mt-16 space-y-4">
-            {series.lessons.length > 0 ? (
-              series.lessons.map((lesson) => (
-                <LessonCard key={lesson.slug} lesson={lesson} seriesSlug={series.slug} />
-              ))
-            ) : (
-              <div className="text-center text-gray-600">
-                <p>No lessons available yet. Check back soon!</p>
-              </div>
-            )}
-          </div>
-        </Container>
-      </div>
+      {firstLesson ? (
+        <LessonContent series={series} lesson={firstLesson} />
+      ) : (
+        <div className="text-gray-600">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">{series.title}</h1>
+          <p className="mt-4">No lessons available yet. Check back soon!</p>
+        </div>
+      )}
     </>
   );
 }

--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Container } from '@/components/ui/Container';
+import { cn, cardSurface, cardHover } from '@/lib/utils';
 
 export const metadata: Metadata = {
   title: 'Get Involved - 02Ship',
@@ -68,9 +69,12 @@ export default function GetInvolvedPage() {
 
         <div className="mx-auto mt-16 grid max-w-3xl grid-cols-1 gap-8 sm:grid-cols-2">
           {roles.map((role) => (
-            <div
+            <a
               key={role.title}
-              className="flex flex-col rounded-xl border border-gray-200 p-6 transition-all hover:border-gray-300 hover:shadow-md"
+              href="https://forms.gle/CuhvaFTHKip9R1At9"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(cardSurface, cardHover, 'flex flex-col p-6')}
             >
               <div className="text-gray-700">{role.icon}</div>
               <h2 className="mt-4 text-xl font-semibold text-gray-900">
@@ -79,7 +83,7 @@ export default function GetInvolvedPage() {
               <p className="mt-2 text-sm leading-relaxed text-gray-600">
                 {role.description}
               </p>
-            </div>
+            </a>
           ))}
         </div>
 

--- a/src/app/news/[date]/page.tsx
+++ b/src/app/news/[date]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { Container } from '@/components/ui/Container';
 import { getNewsByDate, getAllNewsDates } from '@/lib/news';
-import { cn } from '@/lib/utils';
+import { cn, cardSurface, cardHover } from '@/lib/utils';
 import { NewsCategory } from '@/types/news';
 import { BookmarkButton } from '@/components/bookmarks/BookmarkButton';
 
@@ -88,23 +88,21 @@ export default async function DailyNewsPage({ params }: DailyNewsPageProps) {
 
           <div className="mt-8 space-y-6">
             {news.items.map((item, i) => (
-              <article
+              <a
                 key={i}
-                className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm"
+                href={item.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(cardSurface, cardHover, 'block p-5')}
               >
                 <div className="flex items-start gap-4">
                   <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray-100 text-sm font-bold text-gray-700">
                     {item.score}
                   </div>
                   <div className="min-w-0">
-                    <a
-                      href={item.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-lg font-semibold text-gray-900 hover:text-blue-600 transition-colors"
-                    >
+                    <span className="block text-lg font-semibold text-gray-900">
                       {item.title}
-                    </a>
+                    </span>
                     <p className="mt-1 text-gray-600">{item.summary}</p>
                     <div className="mt-2 flex items-center gap-2">
                       <span className="text-xs font-medium text-gray-500">{item.source}</span>
@@ -119,7 +117,7 @@ export default async function DailyNewsPage({ params }: DailyNewsPageProps) {
                     </div>
                   </div>
                 </div>
-              </article>
+              </a>
             ))}
           </div>
 

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Container } from '@/components/ui/Container';
 import { getAllNewsDates } from '@/lib/news';
+import { cn, cardSurface, cardHover } from '@/lib/utils';
 
 export const metadata: Metadata = {
   title: 'Daily News — Curated & Ranked',
@@ -46,7 +47,7 @@ export default async function NewsPage() {
                   <Link
                     key={date}
                     href={`/news/${date}`}
-                    className="block rounded-lg border border-gray-200 bg-white p-4 shadow-sm hover:border-blue-300 hover:shadow-md transition-all"
+                    className={cn(cardSurface, cardHover, 'block p-4')}
                   >
                     <span className="text-lg font-semibold text-gray-900">{formatted}</span>
                   </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Container } from '@/components/ui/Container';
 import { Button } from '@/components/ui/Button';
+import { cn, cardSurface } from '@/lib/utils';
 
 export const metadata: Metadata = {
   title: {
@@ -25,9 +26,8 @@ export default function HomePage() {
               Sydney&apos;s Claude Builder Community
             </h1>
             <p className="mt-6 text-lg leading-8 text-gray-600">
-              Monthly meetups. Small-group ship weeks. Real projects, real
-              outcomes. Join 100+ Claude practitioners building with AI in
-              Sydney.
+              Monthly meetups. Real projects, real outcomes. Join 500+ Claude
+              practitioners building with AI in Sydney.
             </p>
             <div className="mt-10 flex items-center justify-center gap-x-6">
               <Link href="/events">
@@ -48,7 +48,7 @@ export default function HomePage() {
         <Container>
           <div className="mx-auto grid max-w-3xl grid-cols-1 gap-8 text-center sm:grid-cols-3">
             <div>
-              <p className="text-3xl font-bold text-gray-900">100+</p>
+              <p className="text-3xl font-bold text-gray-900">500+</p>
               <p className="mt-1 text-sm text-gray-600">Members</p>
             </div>
             <div>
@@ -71,11 +71,11 @@ export default function HomePage() {
               How the community works
             </h2>
             <p className="mt-4 text-lg text-gray-600">
-              Three ways to level up your Claude skills with other practitioners
+              Two ways to level up your Claude skills with other practitioners
             </p>
           </div>
-          <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-3">
-            <div className="rounded-lg bg-white p-8 shadow-sm">
+          <div className="mx-auto mt-16 grid max-w-3xl grid-cols-1 gap-8 md:grid-cols-2">
+            <div className={cn(cardSurface, 'p-8')}>
               <h3 className="text-xl font-semibold text-gray-900">
                 Monthly Meetups
               </h3>
@@ -85,16 +85,7 @@ export default function HomePage() {
                 work.
               </p>
             </div>
-            <div className="rounded-lg bg-white p-8 shadow-sm">
-              <h3 className="text-xl font-semibold text-gray-900">
-                Cohort
-              </h3>
-              <p className="mt-4 text-gray-600">
-                2-week build sprints in small groups. Pick a project, get
-                accountability and feedback, then demo on day 14.
-              </p>
-            </div>
-            <div className="rounded-lg bg-white p-8 shadow-sm">
+            <div className={cn(cardSurface, 'p-8')}>
               <h3 className="text-xl font-semibold text-gray-900">
                 Member Builds
               </h3>

--- a/src/app/ships/page.tsx
+++ b/src/app/ships/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Container } from '@/components/ui/Container';
 import { getAllShips } from '@/lib/content';
+import { cn, cardSurface, cardHover } from '@/lib/utils';
 
 export const metadata: Metadata = {
   title: 'Ships — What Our Members Built',
@@ -41,10 +42,10 @@ export default async function ShipsPage() {
                 <Link
                   key={ship.slug}
                   href={`/ships/${ship.slug}`}
-                  className="group flex flex-col rounded-xl border border-gray-200 transition-all hover:border-gray-300 hover:shadow-md"
+                  className={cn(cardSurface, cardHover, 'flex flex-col')}
                 >
                   {ship.screenshot ? (
-                    <div className="relative h-48 overflow-hidden rounded-t-xl bg-gray-100">
+                    <div className="relative h-48 overflow-hidden rounded-t-lg bg-gray-100">
                       <Image
                         src={ship.screenshot}
                         alt={`${ship.title} homepage screenshot`}
@@ -54,7 +55,7 @@ export default async function ShipsPage() {
                       />
                     </div>
                   ) : (
-                    <div className="flex h-48 items-center justify-center rounded-t-xl bg-gray-100">
+                    <div className="flex h-48 items-center justify-center rounded-t-lg bg-gray-100">
                       <svg
                         className="h-12 w-12 text-gray-400"
                         fill="none"
@@ -76,7 +77,7 @@ export default async function ShipsPage() {
                         {ship.cohort}
                       </span>
                     )}
-                    <h2 className="text-xl font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
+                    <h2 className="text-xl font-semibold text-gray-900">
                       {ship.title}
                     </h2>
                     <p className="mt-1 text-sm text-gray-500">

--- a/src/components/courses/CourseSidebar.tsx
+++ b/src/components/courses/CourseSidebar.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { createClient } from '@/lib/supabase/client';
+import { cn, lessonHref, cleanLessonTitle } from '@/lib/utils';
+
+interface SidebarLesson {
+  slug: string;
+  title: string;
+}
+
+interface CourseSidebarProps {
+  seriesSlug: string;
+  seriesTitle: string;
+  lessons: SidebarLesson[];
+}
+
+export function CourseSidebar({ seriesSlug, seriesTitle, lessons }: CourseSidebarProps) {
+  const pathname = usePathname();
+  const [isAuthed, setIsAuthed] = useState(false);
+  const [completed, setCompleted] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (!user) return;
+      setIsAuthed(true);
+      supabase
+        .from('lesson_progress')
+        .select('lesson_slug')
+        .eq('user_id', user.id)
+        .eq('series_slug', seriesSlug)
+        .eq('is_completed', true)
+        .then(({ data }) => {
+          setCompleted(new Set((data ?? []).map((r) => r.lesson_slug)));
+        });
+    });
+  }, [seriesSlug]);
+
+  const firstSlug = lessons[0]?.slug;
+  const activeSlug = pathname.startsWith(`/courses/${seriesSlug}/`)
+    ? pathname.slice(`/courses/${seriesSlug}/`.length).split('/')[0]
+    : firstSlug;
+
+  const completedCount = lessons.filter((l) => completed.has(l.slug)).length;
+  const percentage =
+    lessons.length > 0 ? Math.round((completedCount / lessons.length) * 100) : 0;
+
+  const list = (
+    <ol className="space-y-0.5">
+      {lessons.map((lesson, i) => {
+        const isActive = lesson.slug === activeSlug;
+        const isDone = completed.has(lesson.slug);
+        return (
+          <li key={lesson.slug}>
+            <Link
+              href={lessonHref(seriesSlug, lesson.slug, i === 0)}
+              aria-current={isActive ? 'page' : undefined}
+              className={cn(
+                'group flex items-start gap-3 rounded-md px-2 py-2 text-sm transition-colors',
+                isActive ? 'bg-blue-50' : 'hover:bg-gray-50'
+              )}
+            >
+              <span
+                className={cn(
+                  'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border',
+                  isDone ? 'border-blue-600 bg-blue-600' : 'border-gray-300'
+                )}
+                aria-hidden="true"
+              >
+                {isDone && (
+                  <svg className="h-2.5 w-2.5 text-white" viewBox="0 0 12 12" fill="none">
+                    <path
+                      d="M2.5 6.5l2.5 2.5 4.5-5"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                )}
+              </span>
+              <span className="mt-px shrink-0 text-xs tabular-nums text-gray-400">
+                {String(i + 1).padStart(2, '0')}
+              </span>
+              <span
+                className={cn(
+                  'leading-snug',
+                  isActive
+                    ? 'font-semibold text-blue-600'
+                    : 'text-gray-700 group-hover:text-gray-900'
+                )}
+              >
+                {cleanLessonTitle(lesson.title)}
+              </span>
+            </Link>
+          </li>
+        );
+      })}
+    </ol>
+  );
+
+  const heading = (
+    <div className="mb-3">
+      <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+        {seriesTitle}
+      </p>
+      {isAuthed ? (
+        <>
+          <p className="mt-2 text-xs text-gray-500">
+            {completedCount} of {lessons.length} lessons complete
+          </p>
+          <div className="mt-1.5 h-1.5 w-full rounded-full bg-gray-200">
+            <div
+              className="h-1.5 rounded-full bg-blue-600 transition-all"
+              style={{ width: `${percentage}%` }}
+            />
+          </div>
+        </>
+      ) : (
+        <p className="mt-2 text-xs text-gray-500">
+          {lessons.length} {lessons.length === 1 ? 'lesson' : 'lessons'}
+        </p>
+      )}
+    </div>
+  );
+
+  return (
+    <aside className="order-first md:order-last">
+      {/* Mobile: collapsible */}
+      <details className="rounded-lg border border-gray-200 bg-white p-4 md:hidden">
+        <summary className="cursor-pointer text-sm font-semibold text-gray-900">
+          Lessons ({lessons.length})
+        </summary>
+        <div className="mt-4">
+          {heading}
+          {list}
+        </div>
+      </details>
+
+      {/* Desktop: sticky nav */}
+      <nav
+        aria-label="Course lessons"
+        className="hidden md:sticky md:top-24 md:block"
+      >
+        {heading}
+        {list}
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/courses/LessonContent.tsx
+++ b/src/components/courses/LessonContent.tsx
@@ -1,0 +1,231 @@
+import Link from 'next/link';
+import { Series, Lesson } from '@/types/course';
+import { VideoPlayer } from '@/components/courses/VideoPlayer';
+import { Button } from '@/components/ui/Button';
+import { LessonActionsClient } from '@/components/courses/LessonActionsClient';
+import { lessonHref, cleanLessonTitle } from '@/lib/utils';
+
+interface LessonContentProps {
+  series: Series;
+  lesson: Lesson;
+}
+
+export function LessonContent({ series, lesson }: LessonContentProps) {
+  const lessons = series.lessons;
+  const index = lessons.findIndex((l) => l.slug === lesson.slug);
+  const previousLesson = index > 0 ? lessons[index - 1] : null;
+  const nextLesson = index < lessons.length - 1 ? lessons[index + 1] : null;
+
+  return (
+    <article className="max-w-3xl">
+      {/* Header */}
+      <p className="text-sm font-medium text-gray-500">
+        Lesson {index + 1} of {lessons.length}
+      </p>
+      <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+        {cleanLessonTitle(lesson.title)}
+      </h1>
+      <p className="mt-4 text-lg text-gray-600">{lesson.description}</p>
+      <p className="mt-2 text-sm text-gray-500">Duration: {lesson.duration}</p>
+      <LessonActionsClient seriesSlug={series.slug} lessonSlug={lesson.slug} />
+
+      {/* Learning Objectives */}
+      {lesson.learningObjectives && lesson.learningObjectives.length > 0 && (
+        <div className="mt-8 rounded-lg bg-blue-50 p-6">
+          <h2 className="text-xl font-semibold text-gray-900">Learning Objectives</h2>
+          <p className="mt-2 text-sm text-gray-600">
+            By the end of this lesson, you will be able to:
+          </p>
+          <ul className="mt-4 space-y-2">
+            {lesson.learningObjectives.map((objective, i) => (
+              <li key={i} className="flex items-start">
+                <span className="mr-2 text-blue-600">&#10003;</span>
+                <span className="text-gray-700">{objective}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Videos Section */}
+      {lesson.videos && lesson.videos.length > 0 ? (
+        <div className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">Videos</h2>
+          <div className="mt-6 space-y-8">
+            {lesson.videos.map((video, i) => (
+              <div key={i} className="rounded-lg border border-gray-200 p-6">
+                <h3 className="text-xl font-semibold text-gray-900">{video.title}</h3>
+                <p className="mt-2 text-gray-600">{video.description}</p>
+                {video.estimatedDuration && (
+                  <p className="mt-1 text-sm text-gray-500">
+                    Duration: {video.estimatedDuration}
+                  </p>
+                )}
+                <div className="mt-4">
+                  {video.youtubeId && video.youtubeId !== '[To be recorded]' ? (
+                    <VideoPlayer youtubeId={video.youtubeId} title={video.title} />
+                  ) : (
+                    <div className="flex h-64 items-center justify-center rounded-lg bg-gray-100">
+                      <p className="text-gray-500">Video coming soon</p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : lesson.youtubeId ? (
+        // Legacy single video support
+        <div className="mt-8">
+          <VideoPlayer youtubeId={lesson.youtubeId} title={lesson.title} />
+        </div>
+      ) : null}
+
+      {/* Text Sections */}
+      {lesson.textSections && lesson.textSections.length > 0 && (
+        <div className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">Key Concepts</h2>
+          <div className="mt-6 space-y-6">
+            {lesson.textSections.map((section, i) => (
+              <div key={i} className="rounded-lg bg-gray-50 p-6">
+                <h3 className="text-lg font-semibold text-gray-900">{section.title}</h3>
+                <div className="mt-3 whitespace-pre-wrap text-gray-700">{section.content}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Common Mistakes */}
+      {lesson.commonMistakes && lesson.commonMistakes.length > 0 && (
+        <div className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">Common Mistakes & Pitfalls</h2>
+          <div className="mt-6 space-y-4">
+            {lesson.commonMistakes.map((item, i) => (
+              <div key={i} className="rounded-lg border-l-4 border-yellow-500 bg-yellow-50 p-4">
+                <h3 className="font-semibold text-gray-900">&#10060; {item.mistake}</h3>
+                <p className="mt-1 text-gray-700">{item.explanation}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Exercises */}
+      {lesson.exercises && lesson.exercises.length > 0 && (
+        <div className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">Exercises</h2>
+          <div className="mt-6 space-y-6">
+            {lesson.exercises.map((exercise, i) => (
+              <div key={i} className="rounded-lg border border-gray-200 p-6">
+                <div className="flex items-start justify-between">
+                  <h3 className="text-lg font-semibold text-gray-900">
+                    Exercise {i + 1}: {exercise.title}
+                  </h3>
+                  <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700">
+                    {exercise.estimatedTime}
+                  </span>
+                </div>
+                <p className="mt-3 text-gray-700">{exercise.description}</p>
+                <div className="mt-4">
+                  <p className="text-sm font-medium text-gray-900">Expected Output:</p>
+                  <p className="mt-1 text-gray-600">{exercise.output}</p>
+                </div>
+                {Array.isArray(exercise.successCriteria) ? (
+                  <div className="mt-4">
+                    <p className="text-sm font-medium text-gray-900">Success Criteria:</p>
+                    <ul className="mt-2 space-y-1">
+                      {exercise.successCriteria.map((criteria, idx) => (
+                        <li key={idx} className="flex items-start text-sm text-gray-600">
+                          <span className="mr-2">&bull;</span>
+                          <span>{criteria}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : (
+                  <div className="mt-4">
+                    <p className="text-sm italic text-gray-600">{exercise.successCriteria}</p>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Reflection Questions */}
+      {lesson.reflectionQuestions && lesson.reflectionQuestions.length > 0 && (
+        <div className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">Lesson Reflection</h2>
+          <div className="mt-6 rounded-lg bg-purple-50 p-6">
+            <p className="text-sm text-gray-600">
+              Take a moment to reflect on what you&apos;ve learned:
+            </p>
+            <ul className="mt-4 space-y-3">
+              {lesson.reflectionQuestions.map((question, i) => (
+                <li key={i} className="text-gray-700">
+                  <span className="font-medium">{i + 1}.</span> {question}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {/* Resources */}
+      {lesson.resources && lesson.resources.length > 0 && (
+        <div className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">Resources & Further Reading</h2>
+          <div className="mt-6 space-y-3">
+            {lesson.resources.map((resource, i) => (
+              <a
+                key={i}
+                href={resource.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center text-blue-600 hover:text-blue-700"
+              >
+                <span className="mr-2">&#128214;</span>
+                <span>{resource.title}</span>
+                <span className="ml-2">&rarr;</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Legacy Transcript */}
+      {lesson.transcript && (
+        <div className="mt-12">
+          <h2 className="text-2xl font-bold text-gray-900">Transcript</h2>
+          <div className="mt-4 whitespace-pre-wrap text-gray-600">{lesson.transcript}</div>
+        </div>
+      )}
+
+      {/* Navigation */}
+      <div className="mt-12 flex items-center justify-between border-t border-gray-200 pt-8">
+        <div>
+          {previousLesson ? (
+            <Link href={lessonHref(series.slug, previousLesson.slug, index - 1 === 0)}>
+              <Button variant="outline">&larr; Previous Lesson</Button>
+            </Link>
+          ) : (
+            <div />
+          )}
+        </div>
+        <div>
+          {nextLesson ? (
+            <Link href={lessonHref(series.slug, nextLesson.slug, false)}>
+              <Button>Next Lesson &rarr;</Button>
+            </Link>
+          ) : (
+            <Link href={lessonHref(series.slug, lessons[0].slug, true)}>
+              <Button variant="outline">Back to start</Button>
+            </Link>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,8 +2,10 @@
 
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Container } from '@/components/ui/Container';
 import { UserNav } from '@/components/auth/UserNav';
+import { cn } from '@/lib/utils';
 
 const navLinks = [
   { label: 'Courses', href: '/courses' },
@@ -26,6 +28,12 @@ const aboutLinks = [
 export function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const pathname = usePathname();
+
+  const isActive = (href: string) =>
+    pathname === href || pathname.startsWith(`${href}/`);
+  const isGroupActive = (links: { href: string }[]) =>
+    links.some((link) => !link.href.startsWith('http') && isActive(link.href));
 
   useEffect(() => {
     if (!mobileMenuOpen) return;
@@ -54,13 +62,24 @@ export function Header() {
                 <Link
                   key={link.href}
                   href={link.href}
-                  className="text-sm font-medium text-gray-700 hover:text-gray-900"
+                  aria-current={isActive(link.href) ? 'page' : undefined}
+                  className={cn(
+                    'text-sm font-medium',
+                    isActive(link.href)
+                      ? 'font-semibold text-blue-600'
+                      : 'text-gray-700 hover:text-gray-900'
+                  )}
                 >
                   {link.label}
                 </Link>
               ))}
               <div className="group relative">
-                <button aria-haspopup="true" aria-expanded={false} className="flex items-center gap-1 text-sm font-medium text-gray-700 hover:text-gray-900">
+                <button aria-haspopup="true" aria-expanded={false} className={cn(
+                  'flex items-center gap-1 text-sm font-medium',
+                  isGroupActive(shipsLinks)
+                    ? 'font-semibold text-blue-600'
+                    : 'text-gray-700 hover:text-gray-900'
+                )}>
                   Ships
                   <svg className="h-4 w-4 transition-transform group-hover:rotate-180 group-focus-within:rotate-180" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
@@ -73,7 +92,13 @@ export function Header() {
                         key={link.href}
                         href={link.href}
                         {...(link.href.startsWith('http') ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                        className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                        aria-current={!link.href.startsWith('http') && isActive(link.href) ? 'page' : undefined}
+                        className={cn(
+                          'block px-4 py-2 text-sm',
+                          !link.href.startsWith('http') && isActive(link.href)
+                            ? 'font-semibold text-blue-600'
+                            : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
+                        )}
                       >
                         {link.label}
                       </Link>
@@ -82,7 +107,12 @@ export function Header() {
                 </div>
               </div>
               <div className="group relative">
-                <button aria-haspopup="true" aria-expanded={false} className="flex items-center gap-1 text-sm font-medium text-gray-700 hover:text-gray-900">
+                <button aria-haspopup="true" aria-expanded={false} className={cn(
+                  'flex items-center gap-1 text-sm font-medium',
+                  isGroupActive(aboutLinks)
+                    ? 'font-semibold text-blue-600'
+                    : 'text-gray-700 hover:text-gray-900'
+                )}>
                   About
                   <svg className="h-4 w-4 transition-transform group-hover:rotate-180 group-focus-within:rotate-180" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
@@ -94,7 +124,13 @@ export function Header() {
                       <Link
                         key={link.href}
                         href={link.href}
-                        className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                        aria-current={isActive(link.href) ? 'page' : undefined}
+                        className={cn(
+                          'block px-4 py-2 text-sm',
+                          isActive(link.href)
+                            ? 'font-semibold text-blue-600'
+                            : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
+                        )}
                       >
                         {link.label}
                       </Link>
@@ -160,7 +196,13 @@ export function Header() {
                 <Link
                   key={link.href}
                   href={link.href}
-                  className="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                  aria-current={isActive(link.href) ? 'page' : undefined}
+                  className={cn(
+                    'block rounded-md px-3 py-2 text-base font-medium',
+                    isActive(link.href)
+                      ? 'bg-blue-50 font-semibold text-blue-600'
+                      : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
+                  )}
                   onClick={() => setMobileMenuOpen(false)}
                 >
                   {link.label}
@@ -176,7 +218,13 @@ export function Header() {
                       key={link.href}
                       href={link.href}
                       {...(link.href.startsWith('http') ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                      className="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      aria-current={!link.href.startsWith('http') && isActive(link.href) ? 'page' : undefined}
+                      className={cn(
+                        'block rounded-md px-3 py-2 text-base font-medium',
+                        !link.href.startsWith('http') && isActive(link.href)
+                          ? 'bg-blue-50 font-semibold text-blue-600'
+                          : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
+                      )}
                       onClick={() => setMobileMenuOpen(false)}
                     >
                       {link.label}
@@ -193,7 +241,13 @@ export function Header() {
                     <Link
                       key={link.href}
                       href={link.href}
-                      className="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      aria-current={isActive(link.href) ? 'page' : undefined}
+                      className={cn(
+                        'block rounded-md px-3 py-2 text-base font-medium',
+                        isActive(link.href)
+                          ? 'bg-blue-50 font-semibold text-blue-600'
+                          : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
+                      )}
                       onClick={() => setMobileMenuOpen(false)}
                     >
                       {link.label}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,26 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Canonical card styling, defined once so it stays consistent site-wide.
+ * - `cardSurface`: default look (grey border, white bg, subtle shadow). Add padding per context.
+ * - `cardHover`: add to fully-clickable cards. Hover lifts the shadow only — border and text stay put.
+ *   A hover lift always means "this whole card is a link."
+ */
+export const cardSurface = 'rounded-lg border border-gray-200 bg-white shadow-sm';
+export const cardHover = 'transition-shadow hover:shadow-md';
+
+/**
+ * URL for a lesson. The first lesson of a series is canonical at the course root
+ * (`/courses/<series>`), so entering a course opens lesson 1 directly. Lessons 2..N
+ * live at `/courses/<series>/<slug>`.
+ */
+export function lessonHref(seriesSlug: string, lessonSlug: string, isFirst: boolean) {
+  return isFirst ? `/courses/${seriesSlug}` : `/courses/${seriesSlug}/${lessonSlug}`;
+}
+
+/** Strip a redundant "Lesson N - " prefix from a lesson title (the UI shows its own number). */
+export function cleanLessonTitle(title: string) {
+  return title.replace(/^lesson\s+\d+\s*[-–:]\s*/i, '');
+}


### PR DESCRIPTION
## Summary

A UI/UX consistency pass plus a plainbuilt-style course experience.

### Card consistency
- New `cardSurface` / `cardHover` tokens in `src/lib/utils.ts` define one canonical card style.
- Applied across courses, news (list + detail), ships, get-involved, services, community, and homepage feature cards: grey border + white bg by default, a subtle shadow lift on hover, whole card clickable. Removed the inconsistent blue-border / blue-title hovers and the "dead" hovers on non-links.

### Active nav highlight
- The current page is blue + bold in the header (desktop, mobile, and the Ships/About dropdown parents + sub-items), with `aria-current="page"`.

### Course UX (modeled on plainbuilt)
- Persistent two-column layout via a new `[series]/layout.tsx`; right-side lesson-nav sidebar (`CourseSidebar`) with numbered lessons, active highlight, and completion dots.
- Landing on a course opens lesson 1 directly. Lesson 1 is canonical at `/courses/<series>`; lessons 2..N at `/courses/<series>/<slug>`. A shared `LessonContent` renders both.
- Mobile collapses the sidebar into a "Lessons" disclosure.

### Content
- About: the first paragraph now decodes "02Ship = Zero to Ship".
- Homepage: removed the ship-weeks line, bumped 100+ → 500+ members, removed the Cohort feature card and the "Join a Cohort" button.
- Footer: removed the Cohort and Services links.

## Test plan
- `npx tsc --noEmit` clean; `npm run lint` + `npm run build` were green for the card + course-UX work; the later copy/footer edits were verified via type-check and visual review on the dev server.
- Verified visually: active nav highlight, consistent card hovers, course landing opens lesson 1, lesson nav switches active state, mobile sidebar collapses, homepage + footer copy updated.

## Follow-ups (intentionally not in this PR)
- Other "100+" references remain (homepage/layout meta descriptions, community page hero, Discord card count).
- Cohort/ship-weeks still referenced elsewhere (header "Next Cohort", the `/ship-weeks` page, `/ships` empty state, get-involved copy).
- `LessonCard` and `SeriesProgressClient` are now unused (left in place; `LessonCard` has a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)