### PR TITLE
blog: correct product name and persona count in June 16 recap

### DIFF
--- a/content/blog/claude-sydney-meetup-june-16-recap.mdx
+++ b/content/blog/claude-sydney-meetup-june-16-recap.mdx
@@ -55,7 +55,7 @@ In a later demo, one agent tried to run a `CREATE TABLE` query. The tool blocked
 
 ### The live demo
 
-He asked the board a real question: "Should we build a Teams feature for PromPath?"
+He asked the board a real question: "Should we build a Teams feature for PromptPerf?"
 
 - The CFO (Victoria) argued against it. Only 11 paid users.
 - The CTO noted that it needs a large architecture overhaul.
@@ -71,7 +71,7 @@ The demo was small. The real setup is bigger:
 
 - **7 board members**: product, technical, growth, UX, data/AI, finance, and community.
 - Each board member has **3 sub-agents** with different angles, like security, UX, and cloud.
-- **7,600 synthetic personas** vote on a feature before it enters the backlog.
+- **76 synthetic personas** that represent his ideal user base vote on a feature before it enters the backlog.
 - Approved features auto-run the next day through Linear's agent pipeline.
 
 He built this in 3 to 4 hours on a Sunday, using **Google ADK**.


### PR DESCRIPTION
Two factual corrections to the June 16 meetup recap, confirmed by the speaker. The Teams-feature question in Talk 1 was about **PromptPerf** (it read "PromPath"), and the board votes with **76 synthetic personas representing the founder's ideal user base** (it read "7,600").

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
